### PR TITLE
Initial steps on matching current Communicator API to help with unification

### DIFF
--- a/conf/data/mnist.yaml
+++ b/conf/data/mnist.yaml
@@ -2,7 +2,7 @@
 
 # Defines a reusable datamodule config using the torchvision MNIST dataset.
 
-_target_: src.flora.dataset.DataModule
+_target_: src.flora.data.DataModule
 
 # ─────────────
 

--- a/src/flora/Node.py
+++ b/src/flora/Node.py
@@ -204,7 +204,7 @@ class Node:
         round_start_time = time.time()
 
         # Reset round state (simple and explicit)
-        self.algo.reset_round_state()
+        self.algo.round_setup(round_idx)
 
         # Model state before any synchronization
         metrics: dict[str, float] = dict(round_idx=round_idx)

--- a/src/flora/communicator/grpc_client.py
+++ b/src/flora/communicator/grpc_client.py
@@ -24,16 +24,20 @@ from . import grpc_communicator_pb2_grpc as flora_grpc_pb2_grpc
 
 class GrpcClient:
     def __init__(
-        self, client_id: str, master_addr: str = "127.0.0.1", master_port: int = 50051
+        self,
+        client_id: str,
+        master_addr: str,
+        master_port: int,
+        max_send_message_length: int,
+        max_receive_message_length: int,
     ):
         self.client_id = client_id
-        # self.channel = grpc.insecure_channel(master_addr+':'+str(master_port))
-        # 100MB
+        # initialize gRPC channel with configured buffer sizes
         self.channel = grpc.insecure_channel(
             master_addr + ":" + str(master_port),
             options=[
-                ("grpc.max_receive_message_length", 100 * 1024 * 1024),
-                ("grpc.max_send_message_length", 100 * 1024 * 1024),
+                ("grpc.max_receive_message_length", max_receive_message_length),
+                ("grpc.max_send_message_length", max_send_message_length),
             ],
         )
         self.stub = flora_grpc_pb2_grpc.CentralServerStub(self.channel)


### PR DESCRIPTION
NOTE: merge `communicator-cleanup` (#40) into `communicator` first, then this will go into `communicator`