### PR TITLE
Added Configs for Algorithms, Environment Variable Examples, and References to Hydra Doc Pages

### DIFF
--- a/conf/algorithm/base.yaml
+++ b/conf/algorithm/base.yaml
@@ -1,0 +1,13 @@
+# ------------------------------------------------------------------------------
+# Base Algorithm Configuration
+# ------------------------------------------------------------------------------
+
+# Required fields (must be overridden by each algorithm config)
+_target_: ???
+
+local_lr: ???
+max_epochs_per_round: ???
+
+# Defaults
+agg_level: ROUND
+agg_freq: 1

--- a/conf/algorithm/diloco.yaml
+++ b/conf/algorithm/diloco.yaml
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------------------
+# DiLoCo Algorithm Configuration
+#
+# Distributed Local SGD with compression - distributed optimizer on server
+# ------------------------------------------------------------------------------
+
+defaults:
+  - base
+
+# Dotpath to class implementation
+_target_: src.flora.algorithms.DiLoCoNew
+
+# Defaults
+outer_lr: 0.7 # Learning rate for server-side outer optimizer
+outer_momentum: 0.9 # Momentum coefficient for server-side outer optimizer

--- a/conf/algorithm/ditto.yaml
+++ b/conf/algorithm/ditto.yaml
@@ -1,0 +1,15 @@
+# ------------------------------------------------------------------------------
+# Ditto Algorithm Configuration
+#
+# Ditto - personalized federated learning with fairness constraints
+# ------------------------------------------------------------------------------
+
+defaults:
+  - base
+
+# Dotpath to class implementation
+_target_: src.flora.algorithms.DittoNew
+
+# Defaults
+global_lr: 0.01 # Learning rate for global model updates
+ditto_lambda: 0.1 # Regularization coefficient for personalization vs global trade-off

--- a/conf/algorithm/fedavg.yaml
+++ b/conf/algorithm/fedavg.yaml
@@ -1,0 +1,12 @@
+# ------------------------------------------------------------------------------
+# FedAvg Algorithm Configuration
+#
+# Federated Averaging - the baseline federated learning algorithm
+# ------------------------------------------------------------------------------
+
+defaults:
+  - base
+
+# Dotpath to class implementation
+_target_: src.flora.algorithms.FedAvgNew
+# FedAvg has no additional parameters beyond the base algorithm

--- a/conf/algorithm/fedbn.yaml
+++ b/conf/algorithm/fedbn.yaml
@@ -1,0 +1,12 @@
+# ------------------------------------------------------------------------------
+# FedBN Algorithm Configuration
+#
+# FedBN - keeps batch normalization layers local, aggregates other parameters
+# ------------------------------------------------------------------------------
+
+defaults:
+  - base
+
+# Dotpath to class implementation
+_target_: src.flora.algorithms.FedBNNew
+# FedBN has no additional parameters beyond the base algorithm

--- a/conf/algorithm/feddyn.yaml
+++ b/conf/algorithm/feddyn.yaml
@@ -1,0 +1,14 @@
+# ------------------------------------------------------------------------------
+# FedDyn Algorithm Configuration
+#
+# FedDyn - dynamic regularization via correction vectors
+# ------------------------------------------------------------------------------
+
+defaults:
+  - base
+
+# Dotpath to class implementation
+_target_: src.flora.algorithms.FedDynNew
+
+# Defaults
+alpha: 0.1 # Controls strength of correction vector regularization

--- a/conf/algorithm/fedmom.yaml
+++ b/conf/algorithm/fedmom.yaml
@@ -1,0 +1,14 @@
+# ------------------------------------------------------------------------------
+# FedMom Algorithm Configuration
+#
+# Federated Momentum - server-side momentum with velocity buffers
+# ------------------------------------------------------------------------------
+
+defaults:
+  - base
+
+# Dotpath to class implementation
+_target_: src.flora.algorithms.FedMomNew
+
+# Defaults
+momentum: 0.9 # Momentum coefficient for server-side velocity buffer

--- a/conf/algorithm/fednova.yaml
+++ b/conf/algorithm/fednova.yaml
@@ -1,0 +1,14 @@
+# ------------------------------------------------------------------------------
+# FedNova Algorithm Configuration
+#
+# FedNova - normalizes updates by local steps to handle client heterogeneity
+# ------------------------------------------------------------------------------
+
+defaults:
+  - base
+
+# Dotpath to class implementation
+_target_: src.flora.algorithms.FedNovaNew
+
+# Defaults
+weight_decay: 0.0 # L2 regularization strength for local training

--- a/conf/algorithm/fedper.yaml
+++ b/conf/algorithm/fedper.yaml
@@ -1,0 +1,14 @@
+# ------------------------------------------------------------------------------
+# FedPer Algorithm Configuration
+#
+# FedPer - personalized layers kept local, only base model is aggregated
+# ------------------------------------------------------------------------------
+
+defaults:
+  - base
+
+# Dotpath to class implementation
+_target_: src.flora.algorithms.FedPerNew
+
+# Defaults
+personal_layers: ["classifier", "head", "fc"]  # Layer names to keep local (not aggregated)

--- a/conf/algorithm/fedprox.yaml
+++ b/conf/algorithm/fedprox.yaml
@@ -1,0 +1,14 @@
+# ------------------------------------------------------------------------------
+# FedProx Algorithm Configuration
+#
+# FedProx adds a proximal term to stabilize training in heterogeneous environments
+# ------------------------------------------------------------------------------
+
+defaults:
+  - base
+
+# Dotpath to class implementation
+_target_: src.flora.algorithms.FedProxNew
+
+# Defaults
+mu: 0.01 # Proximal term coefficient - controls deviation penalty from global model

--- a/conf/algorithm/moon.yaml
+++ b/conf/algorithm/moon.yaml
@@ -1,0 +1,16 @@
+# ------------------------------------------------------------------------------
+# MOON Algorithm Configuration
+#
+# Model-Contrastive Federated Learning - contrastive learning against global model
+# ------------------------------------------------------------------------------
+
+defaults:
+  - base
+
+# Dotpath to class implementation
+_target_: src.flora.algorithms.MOONNew
+
+# Defaults
+mu: 1.0 # Contrastive loss weight coefficient
+temperature: 0.5 # Temperature parameter for softmax in contrastive loss
+num_prev_models: 1 # Number of previous global models to maintain for contrastive learning

--- a/conf/algorithm/scaffold.yaml
+++ b/conf/algorithm/scaffold.yaml
@@ -1,0 +1,12 @@
+# ------------------------------------------------------------------------------
+# SCAFFOLD Algorithm Configuration
+#
+# SCAFFOLD uses control variates to address client drift in federated learning
+# ------------------------------------------------------------------------------
+
+defaults:
+  - base
+
+# Dotpath to class implementation
+_target_: src.flora.algorithms.ScaffoldNew
+# SCAFFOLD has no additional parameters beyond the base algorithm

--- a/conf/base.yaml
+++ b/conf/base.yaml
@@ -3,6 +3,11 @@
 #
 # This is the foundational configuration that provides common defaults for all FLORA experiments.
 # Other configurations should extend this base and override specific sections as needed.
+#
+# Docs:
+# - https://hydra.cc/docs/patterns/extending_configs/
+# - https://hydra.cc/docs/patterns/configuring_experiments/
+# - https://hydra.cc/docs/advanced/defaults_list/
 # ------------------------------------------------------------------------------
 
 defaults:
@@ -29,6 +34,9 @@ topology: ??? # Must be specified by extending configs
 global_rounds: ???
 
 # ───────────── Hydra Config
+# Docs:
+# - https://hydra.cc/docs/configure_hydra/intro/
+# - https://hydra.cc/docs/configure_hydra/job/
 
 hydra:
   job:
@@ -60,9 +68,10 @@ hydra:
 
   run:
     # Output directory for FL experiment results and logs
+    # Docs: https://hydra.cc/docs/configure_hydra/workdir/
     dir: outputs/${now:%Y-%m-%d}/${hydra.job.config_name}
 
-    # Alternative patterns:
+    # Alternative example patterns:
     # dir: outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}              # Group by date/time
     # dir: outputs/${hydra.job.name}/${now:%Y-%m-%d_%H-%M-%S}   # Group by job name
     # dir: outputs/${algorithm._target_}/${now:%Y-%m-%d}        # Group by algorithm

--- a/conf/base.yaml
+++ b/conf/base.yaml
@@ -31,5 +31,38 @@ global_rounds: ???
 # ───────────── Hydra Config
 
 hydra:
+  job:
+    env_set:
+      # Environment variables for the Hydra job
+      # These can be used to configure the runtime environment for FL workers.
+      # Note: These variables will be copied to all FL workers
+
+      FLORA_ENV_DUMMY1: "dummy_value1" # Example variable for demonstration
+
+      # Example settings:
+
+      # GPU & threading:
+      # CUDA_VISIBLE_DEVICES: "0,1"        # Assign specific GPUs
+      # OMP_NUM_THREADS: 4                 # Limit CPU threads per client
+
+      # PyTorch debugging:
+      # NCCL_DEBUG: INFO                   # GPU communication debug
+      # TORCH_DISTRIBUTED_DEBUG: DETAIL    # Distributed training debug
+      # TORCH_CPP_LOG_LEVEL: INFO          # PyTorch C++ logs
+
+      # Framework logging:
+      # TF_CPP_MIN_LOG_LEVEL: 3            # Suppress TensorFlow warnings
+      # GRPC_VERBOSITY: ERROR              # Minimize gRPC logging
+
+    # Copy local environment variables to FL workers:
+    # env_copy:
+    #   - WANDB_API_KEY # W&B experiment tracking
+
   run:
+    # Output directory for FL experiment results and logs
     dir: outputs/${now:%Y-%m-%d}/${hydra.job.config_name}
+
+    # Alternative patterns:
+    # dir: outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}              # Group by date/time
+    # dir: outputs/${hydra.job.name}/${now:%Y-%m-%d_%H-%M-%S}   # Group by job name
+    # dir: outputs/${algorithm._target_}/${now:%Y-%m-%d}        # Group by algorithm

--- a/conf/test_mnist_base.yaml
+++ b/conf/test_mnist_base.yaml
@@ -11,18 +11,15 @@
 
 defaults:
   - base
+  - algorithm: fedavg
   - model: simple_cnn
   - data: mnist
-  - _self_
 
 # ───────────── FL Algorithm Config
 
-algo:
-  _target_: src.flora.algorithms.FedAvgNew
+algorithm:
   local_lr: 0.01
   max_epochs_per_round: 2
-  agg_freq: 1
-  agg_level: ROUND
 
 # ───────────── Model Config
 
@@ -39,10 +36,6 @@ data: # overrides the default mnist datamodule
     batch_size: 16
   val:
     batch_size: 16
-
-# ───────────── Topology and Communication Config
-
-topology: ??? # Mandatory marker; composer must override this value
 
 # ───────────── FL Engine Config
 

--- a/conf/test_mnist_centralized_grpc.yaml
+++ b/conf/test_mnist_centralized_grpc.yaml
@@ -8,7 +8,6 @@
 defaults:
   - test_mnist_base
   - topology: centralized
-  - _self_
 
 # ───────────── Topology Config
 

--- a/conf/test_mnist_multigroup.yaml
+++ b/conf/test_mnist_multigroup.yaml
@@ -9,7 +9,6 @@
 defaults:
   - test_mnist_base
   - topology: multigroup
-  - _self_
 
 # ───────────── Topology Config
 

--- a/main.sh
+++ b/main.sh
@@ -6,29 +6,16 @@ echo "##########################################################################
 echo "###########################################################################"
 echo
 
-set -euo pipefail  # Exit on error, undefined variable, or failed command in a pipeline
-set -x              # Print each command before executing it (for debugging)
+set -euo pipefail # Exit on error, undefined variable, or failed command in a pipeline
+set -x            # Print each command before executing it (for debugging)
 
 # =========================================
-# Set debugging environment variables
 
-export PYTHONUNBUFFERED=1              # Ensure Python output isn't buffered
+export PYTHONUNBUFFERED=1 # Immediate Python output
+export HYDRA_FULL_ERROR=1 # Full Hydra error traces
+export RAY_DEDUP_LOGS=0   # Show all FL node logs
 
-# export TF_CPP_MIN_LOG_LEVEL=3          # Suppress TensorFlow warnings  
-# export GRPC_VERBOSITY=ERROR
-
-# PyTorch Distributed debugging and settings
-# export TORCH_DISTRIBUTED_DEBUG=DETAIL  # Enable detailed debugging output for torch.distributed
-# export TORCH_CPP_LOG_LEVEL=INFO        # Get more detailed C++ logs
-# export GLOO_SOCKET_IFNAME=lo           # Force Gloo to use loopback interface
-# export NCCL_DEBUG=WARN                 # NCCL debugging (for GPU communication)
-
-# Ray settings
-export RAY_DEDUP_LOGS=0                # Show all logs, don't deduplicate
-
-# Hydra settings
-export HYDRA_FULL_ERROR=1              # Show full error trace for Hydra
-
+# Also check the yaml configuration files for any additional per-experiment environment variables.
 
 # =========================================
 
@@ -37,6 +24,7 @@ python -m grpc_tools.protoc -I. --python_out=. --grpc_python_out=. ./src/flora/c
 
 # Run the main script
 # NOTE: additional arguments passed to the `main.sh` script are forwarded to the Python script
+# https://hydra.cc/docs/advanced/hydra-command-line-flags/
 python -u main.py "$@"
 
 # python -u main.py --config-name test_mnist_grpc "$@"

--- a/src/flora/Engine.py
+++ b/src/flora/Engine.py
@@ -58,7 +58,7 @@ class Engine(SetupMixin):
 
         self.topology: BaseTopology = instantiate(
             self.flora_cfg.topology,
-            algo_cfg=self.flora_cfg.algo,
+            algo_cfg=self.flora_cfg.algorithm,
             model_cfg=self.flora_cfg.model,
             data_cfg=self.flora_cfg.data,
             log_dir=self.hydra_cfg.runtime.output_dir,

--- a/src/flora/Node.py
+++ b/src/flora/Node.py
@@ -50,7 +50,7 @@ class NodeConfig:
     """Configuration for creating a Ray actor Node."""
 
     id: str
-    algo_cfg: DictConfig
+    algorithm_cfg: DictConfig
     local_comm_cfg: DictConfig
     local_model_cfg: DictConfig
     local_data_cfg: DictConfig
@@ -99,8 +99,8 @@ class Node(SetupMixin):
         # self.tb_writer: SummaryWriter = SummaryWriter(log_dir=log_dir)
 
         # Federated learning algorithm
-        self.algo: BaseAlgorithm = instantiate(
-            cfg.algo_cfg,
+        self.algorithm: BaseAlgorithm = instantiate(
+            cfg.algorithm_cfg,
             local_comm=self.local_comm,
             global_comm=self.global_comm,
             local_model=self.local_model,
@@ -143,7 +143,7 @@ class Node(SetupMixin):
             self.global_comm.setup()
 
         # Setup algorithm
-        self.algo.setup(device=self.device)
+        self.algorithm.setup(device=self.device)
         # summary(self.model, verbose=1)
 
     def round_exec(self, round_idx: int) -> dict[str, float]:
@@ -158,9 +158,9 @@ class Node(SetupMixin):
             Dictionary with training metrics and results
         """
         if not self.is_ready:
-            raise RuntimeError(f"Node {self.id} not ready - call setup() first")
+            raise RuntimeError(f"Node not ready - call setup() first")
 
-        metrics = self.algo.round_exec(
+        metrics = self.algorithm.round_exec(
             self.datamodule,
             round_idx,
         )

--- a/src/flora/algorithms/diloco.py
+++ b/src/flora/algorithms/diloco.py
@@ -153,14 +153,12 @@ class DiLoCoNew(BaseAlgorithm):
         self,
         outer_lr: float = 0.7,
         outer_momentum: float = 0.9,
-        inner_steps: int = 5,
         **kwargs,
     ):
         """Initialize DiLoCo algorithm with distributed optimizer parameters."""
         super().__init__(**kwargs)
         self.outer_lr = outer_lr
         self.outer_momentum = outer_momentum
-        self.inner_steps = inner_steps
 
     def _setup(self, device: torch.device) -> None:
         """

--- a/src/flora/algorithms/scaffold.py
+++ b/src/flora/algorithms/scaffold.py
@@ -180,10 +180,6 @@ class ScaffoldNew(BaseAlgorithm):
     Gradient correction and control variate updates are performed each round.
     """
 
-    def __init__(self, **kwargs):
-        """Initialize SCAFFOLD algorithm with granularity validation."""
-        super().__init__(**kwargs)
-
     def _setup(self, device: torch.device) -> None:
         """
         SCAFFOLD-specific setup: initialize control variates and tracking structures.

--- a/src/flora/topology/CentralizedTopology.py
+++ b/src/flora/topology/CentralizedTopology.py
@@ -101,7 +101,7 @@ class CentralizedTopology(BaseTopology):
             node_config = NodeConfig(
                 id=node_id,
                 local_comm_cfg=__local_comm_cfg,
-                algo_cfg=algo_cfg,
+                algorithm_cfg=algo_cfg,
                 local_model_cfg=model_cfg,
                 local_data_cfg=node_data_cfg,
             )


### PR DESCRIPTION
Add template configuration files for all algorithms, including the corresponding target dot paths to the class implementation, along with all their required and optional fields with default values.

See the updated usage in `conf/test_mnist_base.yaml`, where we select fedavg as the default and only provide the required fields.

Additionally, updated `base.yaml` with various examples for setting environment variables and output directory patterns.