### PR TITLE
Feature/centralized compression slurm: Centralized Slurm sync with compression (grad + param) — closes issue 90

### DIFF
--- a/conf/base.yaml
+++ b/conf/base.yaml
@@ -198,3 +198,5 @@ engine:
       scheme: topk   # topk | qsgd
       compress_ratio: 0.01
       bit_width: 8   # qsgd only: s where levels = 2^s
+  classic:
+    aggregate_payload: params   # params | gradients

--- a/conf/test_pi_centralized_sync_grad_cifar10_resnet18_grpc.yaml
+++ b/conf/test_pi_centralized_sync_grad_cifar10_resnet18_grpc.yaml
@@ -1,0 +1,63 @@
+# PI centralized — synchronous gradient aggregation (CIFAR-10, ResNet-18, gRPC).
+# Per-minibatch grad sync; deferred optimizer.step; no compression.
+
+defaults:
+  - base
+  - override topology: centralized
+  - override algorithm: synchronousDP
+  - override algorithm/schedules/aggregation: batch_end
+  - override model: resnet18
+  - override datamodule: cifar10
+  - _self_
+
+engine:
+  mode: slurm
+  communication_mode: classic
+  classic:
+    aggregate_payload: gradients
+
+topology:
+  num_clients: 6
+  local_comm:
+    _target_: src.omnifed.communicator.GrpcCommunicator
+    master_addr: 127.0.0.1
+    master_port: 50051
+    communicate_params: false
+    normalize_by_total_samples: false
+    max_retries: 36
+    retry_delay: 5.0
+    client_timeout: 180.0
+  overrides:
+    0:
+      datamodule:
+        train: null
+
+algorithm:
+  local_lr: 0.001
+  max_epochs_per_round: 1
+  schedules:
+    evaluation:
+      experiment_start:
+        enabled: true
+      experiment_end:
+        enabled: true
+      pre_aggregation:
+        enabled: false
+      post_aggregation:
+        enabled: false
+
+model:
+  num_classes: 10
+
+datamodule:
+  train:
+    batch_size: 128
+  eval:
+    batch_size: 128
+
+global_rounds: 4
+
+slurm:
+  enabled: true
+  nodes: 7
+  ntasks_per_node: 1

--- a/conf/test_pi_centralized_sync_grad_cifar10_resnet18_grpc_qsgd.yaml
+++ b/conf/test_pi_centralized_sync_grad_cifar10_resnet18_grpc_qsgd.yaml
@@ -1,0 +1,16 @@
+# PI centralized — sync grad + QSGD over gRPC (CIFAR-10, ResNet-18).
+
+defaults:
+  - test_pi_centralized_sync_grad_cifar10_resnet18_grpc
+  - _self_
+
+topology:
+  local_comm:
+    client_compressor:
+      _target_: src.omnifed.communicator.compression.quantization.QSGDQuantCompression
+      device: cpu
+      bit_width: 4
+    server_compressor:
+      _target_: src.omnifed.communicator.compression.quantization.QSGDQuantCompression
+      device: cpu
+      bit_width: 4

--- a/conf/test_pi_centralized_sync_grad_cifar10_resnet18_grpc_topk.yaml
+++ b/conf/test_pi_centralized_sync_grad_cifar10_resnet18_grpc_topk.yaml
@@ -1,0 +1,16 @@
+# PI centralized — sync grad + Top-K over gRPC (CIFAR-10, ResNet-18).
+
+defaults:
+  - test_pi_centralized_sync_grad_cifar10_resnet18_grpc
+  - _self_
+
+topology:
+  local_comm:
+    client_compressor:
+      _target_: src.omnifed.communicator.compression.sparsification.TopKCompression
+      device: cpu
+      compress_ratio: 0.01
+    server_compressor:
+      _target_: src.omnifed.communicator.compression.sparsification.TopKCompression
+      device: cpu
+      compress_ratio: 0.01

--- a/conf/test_pi_centralized_sync_grad_cifar10_resnet18_torchdist.yaml
+++ b/conf/test_pi_centralized_sync_grad_cifar10_resnet18_torchdist.yaml
@@ -1,0 +1,15 @@
+# PI centralized — synchronous gradient aggregation via TorchDist (CIFAR-10, ResNet-18).
+# Dense (no compression). Sibling of the gRPC sync-grad presets.
+
+defaults:
+  - test_pi_centralized_sync_grad_cifar10_resnet18_grpc
+  - _self_
+
+topology:
+  local_comm:
+    _target_: src.omnifed.communicator.TorchDistCommunicator
+    backend: nccl
+    master_addr: ${oc.env:MASTER_ADDR,127.0.0.1}
+    master_port: ${oc.env:MASTER_PORT,29500}
+    communicate_params: false
+    timeout: 600

--- a/conf/test_pi_centralized_sync_grad_cifar10_resnet18_torchdist_qsgd.yaml
+++ b/conf/test_pi_centralized_sync_grad_cifar10_resnet18_torchdist_qsgd.yaml
@@ -1,0 +1,12 @@
+# PI centralized — sync grad + QSGD over TorchDist (CIFAR-10, ResNet-18).
+
+defaults:
+  - test_pi_centralized_sync_grad_cifar10_resnet18_torchdist
+  - _self_
+
+topology:
+  local_comm:
+    compressor:
+      _target_: src.omnifed.communicator.compression.quantization.QSGDQuantCompression
+      device: cuda
+      bit_width: 4

--- a/conf/test_pi_centralized_sync_grad_cifar10_resnet18_torchdist_topk.yaml
+++ b/conf/test_pi_centralized_sync_grad_cifar10_resnet18_torchdist_topk.yaml
@@ -1,0 +1,12 @@
+# PI centralized — sync grad + Top-K over TorchDist (CIFAR-10, ResNet-18).
+
+defaults:
+  - test_pi_centralized_sync_grad_cifar10_resnet18_torchdist
+  - _self_
+
+topology:
+  local_comm:
+    compressor:
+      _target_: src.omnifed.communicator.compression.sparsification.TopKCompression
+      device: cuda
+      compress_ratio: 0.01

--- a/conf/test_pi_centralized_sync_param_cifar10_resnet18_grpc.yaml
+++ b/conf/test_pi_centralized_sync_param_cifar10_resnet18_grpc.yaml
@@ -1,0 +1,63 @@
+# PI centralized — synchronous parameter aggregation (CIFAR-10, ResNet-18, gRPC).
+# Per-minibatch param sync; optimizer.step before sync; dense (no compression).
+
+defaults:
+  - base
+  - override topology: centralized
+  - override algorithm: synchronousDP
+  - override algorithm/schedules/aggregation: batch_end
+  - override model: resnet18
+  - override datamodule: cifar10
+  - _self_
+
+engine:
+  mode: slurm
+  communication_mode: classic
+  classic:
+    aggregate_payload: params
+
+topology:
+  num_clients: 6
+  local_comm:
+    _target_: src.omnifed.communicator.GrpcCommunicator
+    master_addr: 127.0.0.1
+    master_port: 50051
+    communicate_params: true
+    normalize_by_total_samples: false
+    max_retries: 36
+    retry_delay: 5.0
+    client_timeout: 180.0
+  overrides:
+    0:
+      datamodule:
+        train: null
+
+algorithm:
+  local_lr: 0.001
+  max_epochs_per_round: 1
+  schedules:
+    evaluation:
+      experiment_start:
+        enabled: true
+      experiment_end:
+        enabled: true
+      pre_aggregation:
+        enabled: false
+      post_aggregation:
+        enabled: false
+
+model:
+  num_classes: 10
+
+datamodule:
+  train:
+    batch_size: 128
+  eval:
+    batch_size: 128
+
+global_rounds: 4
+
+slurm:
+  enabled: true
+  nodes: 7
+  ntasks_per_node: 1

--- a/conf/test_pi_centralized_sync_param_cifar10_resnet18_grpc_qsgd.yaml
+++ b/conf/test_pi_centralized_sync_param_cifar10_resnet18_grpc_qsgd.yaml
@@ -1,0 +1,17 @@
+# PI centralized — sync param + QSGD over gRPC (CIFAR-10, ResNet-18).
+# Exploratory: compresses weights (not grads). BN still in payload until dense-BN split.
+
+defaults:
+  - test_pi_centralized_sync_param_cifar10_resnet18_grpc
+  - _self_
+
+topology:
+  local_comm:
+    client_compressor:
+      _target_: src.omnifed.communicator.compression.quantization.QSGDQuantCompression
+      device: cpu
+      bit_width: 4
+    server_compressor:
+      _target_: src.omnifed.communicator.compression.quantization.QSGDQuantCompression
+      device: cpu
+      bit_width: 4

--- a/conf/test_pi_centralized_sync_param_cifar10_resnet18_grpc_topk.yaml
+++ b/conf/test_pi_centralized_sync_param_cifar10_resnet18_grpc_topk.yaml
@@ -1,0 +1,17 @@
+# PI centralized — sync param + Top-K over gRPC (CIFAR-10, ResNet-18).
+# Exploratory: compresses weights (not grads). BN still in payload until dense-BN split.
+
+defaults:
+  - test_pi_centralized_sync_param_cifar10_resnet18_grpc
+  - _self_
+
+topology:
+  local_comm:
+    client_compressor:
+      _target_: src.omnifed.communicator.compression.sparsification.TopKCompression
+      device: cpu
+      compress_ratio: 0.01
+    server_compressor:
+      _target_: src.omnifed.communicator.compression.sparsification.TopKCompression
+      device: cpu
+      compress_ratio: 0.01

--- a/conf/test_pi_centralized_sync_param_cifar10_resnet18_torchdist.yaml
+++ b/conf/test_pi_centralized_sync_param_cifar10_resnet18_torchdist.yaml
@@ -1,0 +1,15 @@
+# PI centralized — synchronous parameter aggregation via TorchDist (CIFAR-10, ResNet-18).
+# Dense (no compression). Sibling of the gRPC sync-param preset.
+
+defaults:
+  - test_pi_centralized_sync_param_cifar10_resnet18_grpc
+  - _self_
+
+topology:
+  local_comm:
+    _target_: src.omnifed.communicator.TorchDistCommunicator
+    backend: nccl
+    master_addr: ${oc.env:MASTER_ADDR,127.0.0.1}
+    master_port: ${oc.env:MASTER_PORT,29500}
+    communicate_params: true
+    timeout: 600

--- a/conf/test_pi_centralized_sync_param_cifar10_resnet18_torchdist_qsgd.yaml
+++ b/conf/test_pi_centralized_sync_param_cifar10_resnet18_torchdist_qsgd.yaml
@@ -1,0 +1,13 @@
+# PI centralized — sync param + QSGD over TorchDist (CIFAR-10, ResNet-18).
+# Exploratory: compresses weights (not grads). BN still in payload until dense-BN split.
+
+defaults:
+  - test_pi_centralized_sync_param_cifar10_resnet18_torchdist
+  - _self_
+
+topology:
+  local_comm:
+    compressor:
+      _target_: src.omnifed.communicator.compression.quantization.QSGDQuantCompression
+      device: cuda
+      bit_width: 4

--- a/conf/test_pi_centralized_sync_param_cifar10_resnet18_torchdist_topk.yaml
+++ b/conf/test_pi_centralized_sync_param_cifar10_resnet18_torchdist_topk.yaml
@@ -1,0 +1,13 @@
+# PI centralized — sync param + Top-K over TorchDist (CIFAR-10, ResNet-18).
+# Exploratory: compresses weights (not grads). BN still in payload until dense-BN split.
+
+defaults:
+  - test_pi_centralized_sync_param_cifar10_resnet18_torchdist
+  - _self_
+
+topology:
+  local_comm:
+    compressor:
+      _target_: src.omnifed.communicator.compression.sparsification.TopKCompression
+      device: cuda
+      compress_ratio: 0.01

--- a/scripts/classic_summary_standalone.py
+++ b/scripts/classic_summary_standalone.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""
+Build classic centralized per-round summary from an existing Hydra run directory.
+
+No OmniFed imports — stdlib only. Safe to copy to Frontier without rsync:
+
+  python3 classic_summary_standalone.py /path/to/test_pi_..._grpc_grad_a
+
+Reads Node0.1 … Node0.6/metrics_full.csv (primary). Falls back to parsing
+slurm-*.out for End sync/eval context lines if metrics_full is missing.
+"""
+
+from __future__ import annotations
+
+import csv
+import glob
+import io
+import math
+import os
+import re
+import sys
+from collections import defaultdict
+from typing import Any, DefaultDict, Dict, List, Optional, Tuple
+
+_META_COLS = ("global_step", "round_idx", "epoch_idx", "batch_idx")
+
+
+def _f(val: Any) -> Optional[float]:
+    if val is None or val == "":
+        return None
+    try:
+        x = float(val)
+        if math.isnan(x) or math.isinf(x):
+            return None
+        return x
+    except (TypeError, ValueError):
+        return None
+
+
+def _metric_seconds(row: Dict[str, Any], base: str) -> Optional[float]:
+    v = _f(row.get(base))
+    if v is not None:
+        return v
+    return _f(row.get(f"sync/{base}"))
+
+
+def _load_metrics_full_context(csv_path: str, agg_context: str) -> List[Dict[str, Any]]:
+    groups: Dict[tuple, Dict[str, Any]] = {}
+    try:
+        with open(csv_path, newline="", encoding="utf-8") as f:
+            for row in csv.DictReader(f):
+                if row.get("agg_ctx") != agg_context:
+                    continue
+                key_parts: List[tuple[str, str]] = []
+                meta: Dict[str, Any] = {}
+                for col in _META_COLS:
+                    val = row.get(col)
+                    if val is None or val == "":
+                        continue
+                    meta[col] = val
+                    key_parts.append((col, str(val)))
+                gkey = tuple(key_parts)
+                if gkey not in groups:
+                    groups[gkey] = dict(meta)
+                mk = row.get("metric_key") or ""
+                if mk:
+                    groups[gkey][mk] = row.get("metric_val")
+    except OSError:
+        return []
+    return list(groups.values())
+
+
+def _round_idx(row: Dict[str, Any]) -> Optional[int]:
+    raw = row.get("round_idx")
+    if raw is None or raw == "":
+        return None
+    try:
+        return int(float(raw))
+    except (TypeError, ValueError):
+        return None
+
+
+def _max_sync_metric(rows: List[Dict[str, Any]], round_idx: int, base: str) -> Optional[float]:
+    vals: List[float] = []
+    for row in rows:
+        if _round_idx(row) != round_idx:
+            continue
+        v = _metric_seconds(row, base)
+        if v is not None:
+            vals.append(v)
+    return max(vals) if vals else None
+
+
+def _eval_losses(rows: List[Dict[str, Any]], round_idx: int) -> List[float]:
+    out: List[float] = []
+    for row in rows:
+        if _round_idx(row) != round_idx:
+            continue
+        v = row.get("eval/loss", row.get("loss"))
+        fv = _f(v)
+        if fv is not None:
+            out.append(fv)
+    return out
+
+
+def _format_ms(seconds: Optional[float]) -> str:
+    if seconds is None:
+        return "—"
+    return f"{1000.0 * seconds:.2f}"
+
+
+def _build_from_metrics_full(run_dir: str) -> Optional[Tuple[str, str]]:
+    sync_by_node: List[List[Dict[str, Any]]] = []
+    eval_by_node: List[List[Dict[str, Any]]] = []
+    for i in range(1, 7):
+        full = os.path.join(run_dir, f"Node0.{i}", "metrics_full.csv")
+        if not os.path.isfile(full):
+            continue
+        sync_by_node.append(_load_metrics_full_context(full, "sync"))
+        eval_by_node.append(_load_metrics_full_context(full, "eval"))
+
+    if not sync_by_node and not eval_by_node:
+        return None
+
+    rounds: set[int] = set()
+    for sync_rows in sync_by_node:
+        for row in sync_rows:
+            r = _round_idx(row)
+            if r is not None:
+                rounds.add(r)
+    for eval_rows in eval_by_node:
+        for row in eval_rows:
+            r = _round_idx(row)
+            if r is not None:
+                rounds.add(r)
+
+    hdr = [
+        "round_idx",
+        "grpc_agg_max_ms",
+        "grad_apply_max_ms",
+        "eval_loss_avg",
+        "n_eval_trainers",
+    ]
+    md = [
+        "",
+        "### Classic per-round summary (from Node0.*/metrics_full.csv)",
+        "",
+        "| " + " | ".join(hdr) + " |",
+        "|" + "|".join([":---"] * len(hdr)) + "|",
+    ]
+    buf = io.StringIO()
+    w = csv.writer(buf)
+    w.writerow(hdr)
+
+    for ridx in sorted(rounds):
+        agg_vals: List[float] = []
+        apply_vals: List[float] = []
+        for sync_rows in sync_by_node:
+            xa = _max_sync_metric(sync_rows, ridx, "local_agg_time")
+            xg = _max_sync_metric(sync_rows, ridx, "grad_apply_time")
+            if xa is not None:
+                agg_vals.append(xa)
+            if xg is not None:
+                apply_vals.append(xg)
+        losses: List[float] = []
+        for eval_rows in eval_by_node:
+            losses.extend(_eval_losses(eval_rows, ridx))
+        loss_avg = sum(losses) / len(losses) if losses else None
+        loss_txt = f"{loss_avg:.6f}" if loss_avg is not None else "—"
+
+        row = [
+            ridx,
+            _format_ms(max(agg_vals) if agg_vals else None),
+            _format_ms(max(apply_vals) if apply_vals else None),
+            loss_txt,
+            str(len(losses)),
+        ]
+        w.writerow(row)
+        md.append("| " + " | ".join(str(c) for c in row) + " |")
+
+    return "\n".join(md) + "\n", buf.getvalue()
+
+
+_END_CTX_RE = re.compile(
+    r"End (?P<ctx>sync|eval) context @ .*?\(ROUND_IDX=(?P<round>\d+).*?\|\s*(?P<metrics>.+)$"
+)
+_KV_RE = re.compile(r"([^=;]+)=([^;]+)")
+
+
+def _parse_metric_blob(blob: str) -> Dict[str, float]:
+    out: Dict[str, float] = {}
+    for m in _KV_RE.finditer(blob):
+        key = m.group(1).strip()
+        fv = _f(m.group(2).strip())
+        if fv is not None:
+            out[key] = fv
+    return out
+
+
+def _build_from_slurm_log(run_dir: str) -> Optional[Tuple[str, str]]:
+    logs = sorted(glob.glob(os.path.join(run_dir, "slurm-*.out")))
+    if not logs:
+        return None
+
+    sync_agg: DefaultDict[int, List[float]] = defaultdict(list)
+    sync_apply: DefaultDict[int, List[float]] = defaultdict(list)
+    eval_loss: DefaultDict[int, List[float]] = defaultdict(list)
+
+    for log_path in logs:
+        with open(log_path, encoding="utf-8", errors="replace") as f:
+            for line in f:
+                line = line.strip()
+                m = _END_CTX_RE.search(line)
+                if not m:
+                    continue
+                ridx = int(m.group("round"))
+                metrics = _parse_metric_blob(m.group("metrics"))
+                if m.group("ctx") == "sync":
+                    for key in ("local_agg_time", "sync/local_agg_time"):
+                        if key in metrics:
+                            sync_agg[ridx].append(metrics[key])
+                            break
+                    for key in ("grad_apply_time", "sync/grad_apply_time"):
+                        if key in metrics:
+                            sync_apply[ridx].append(metrics[key])
+                            break
+                else:
+                    for key in ("eval/loss", "loss"):
+                        if key in metrics:
+                            eval_loss[ridx].append(metrics[key])
+                            break
+
+    rounds = sorted(set(sync_agg) | set(sync_apply) | set(eval_loss))
+    if not rounds:
+        return None
+
+    hdr = [
+        "round_idx",
+        "grpc_agg_max_ms",
+        "grad_apply_max_ms",
+        "eval_loss_avg",
+        "n_eval_trainers",
+    ]
+    md = [
+        "",
+        f"### Classic per-round summary (from {os.path.basename(logs[0])} — log fallback)",
+        "",
+        "| " + " | ".join(hdr) + " |",
+        "|" + "|".join([":---"] * len(hdr)) + "|",
+    ]
+    buf = io.StringIO()
+    w = csv.writer(buf)
+    w.writerow(hdr)
+
+    for ridx in rounds:
+        losses = eval_loss.get(ridx, [])
+        loss_avg = sum(losses) / len(losses) if losses else None
+        loss_txt = f"{loss_avg:.6f}" if loss_avg is not None else "—"
+        row = [
+            ridx,
+            _format_ms(max(sync_agg[ridx]) if sync_agg[ridx] else None),
+            _format_ms(max(sync_apply[ridx]) if sync_apply[ridx] else None),
+            loss_txt,
+            str(len(losses)),
+        ]
+        w.writerow(row)
+        md.append("| " + " | ".join(str(c) for c in row) + " |")
+
+    return "\n".join(md) + "\n", buf.getvalue()
+
+
+def main() -> None:
+    run_dir = os.path.abspath(sys.argv[1] if len(sys.argv) > 1 else os.getcwd())
+    result = _build_from_metrics_full(run_dir)
+    source = "metrics_full.csv"
+    if result is None:
+        result = _build_from_slurm_log(run_dir)
+        source = "slurm-*.out"
+    if result is None:
+        print(
+            f"No summary data found under {run_dir}\n"
+            "Expected Node0.1-6/metrics_full.csv or slurm-*.out with "
+            "'End sync/eval context' lines.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    md, csv_text = result
+    eng = os.path.join(run_dir, "engine")
+    os.makedirs(eng, exist_ok=True)
+    for path in (
+        os.path.join(eng, "classic_per_round_summary.csv"),
+        os.path.join(run_dir, "classic_per_round_summary.csv"),
+    ):
+        with open(path, "w", encoding="utf-8", newline="") as f:
+            f.write(csv_text)
+    with open(os.path.join(eng, "classic_per_round_summary.txt"), "w", encoding="utf-8") as f:
+        f.write(md)
+
+    print(f"Wrote classic_per_round_summary.csv ({source})", flush=True)
+    print(md.strip(), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/export_classic_per_rank_logs.py
+++ b/scripts/export_classic_per_rank_logs.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""
+Export per-rank per-iteration CSV + GPU memory logs from a classic Slurm run.
+
+Usage (on Frontier, from run directory or parent):
+
+  python3 scripts/export_classic_per_rank_logs.py \\
+    outputs/2026-08-06_12-14-36/test_pi_centralized_sync_grad_cifar10_resnet18_torchdist
+
+Writes:
+  engine/classic_per_rank_notion.txt   — paste into Notion (Rank0 … Rank6 sections)
+  engine/classic_per_rank_logs.zip     — all rank CSV + GPU log files
+
+Stdlib only — safe to run without full OmniFed imports.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+
+def _find_engine_dir(run_dir: Path) -> Path:
+    eng = run_dir / "engine"
+    if eng.is_dir():
+        return eng
+    raise SystemExit(f"No engine/ directory under {run_dir}")
+
+
+def _detect_ranks(engine: Path) -> list[int]:
+    ranks: set[int] = set()
+    for pattern in (
+        "rank*_classic_per_iteration_summary.csv",
+        "rank*_gpu_memory.log",
+    ):
+        for path in engine.glob(pattern):
+            match = re.match(r"rank(\d+)_", path.name)
+            if match:
+                ranks.add(int(match.group(1)))
+    return sorted(ranks)
+
+
+def _read_text(path: Path, *, max_lines: int | None) -> str:
+    if not path.is_file():
+        return f"(missing: {path.name})\n"
+    lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    if max_lines is not None and len(lines) > max_lines:
+        keep_tail = max(1, max_lines // 5)
+        keep_head = max(1, max_lines - keep_tail - 1)
+        omitted = len(lines) - keep_head - keep_tail
+        lines = (
+            lines[:keep_head]
+            + [f"... truncated {omitted} lines ..."]
+            + lines[-keep_tail:]
+        )
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def build_notion_text(
+    engine: Path,
+    ranks: list[int],
+    *,
+    max_iter_lines: int | None,
+    max_gpu_lines: int | None,
+) -> str:
+    parts: list[str] = []
+    parts.append(f"Run: {engine.parent.name}\nEngine: {engine}\n")
+
+    for rank in ranks:
+        iter_path = engine / f"rank{rank}_classic_per_iteration_summary.csv"
+        gpu_path = engine / f"rank{rank}_gpu_memory.log"
+
+        iter_body = _read_text(iter_path, max_lines=max_iter_lines)
+        gpu_body = _read_text(gpu_path, max_lines=max_gpu_lines)
+
+        block = []
+        block.append(f"Rank{rank}\n")
+        block.append("=" * 40 + "\n\n")
+        block.append("Per iteration summary\n---------------------\n\n")
+        block.append("```csv\n")
+        block.append(iter_body if iter_body.strip() else "(empty)\n")
+        block.append("```\n\n")
+        block.append("GPU logs\n--------\n\n")
+        block.append("```csv\n")
+        block.append(gpu_body if gpu_body.strip() else "(empty)\n")
+        block.append("```\n\n")
+        parts.append("".join(block))
+
+    return "\n".join(parts).rstrip() + "\n"
+
+
+def write_zip(engine: Path, ranks: list[int], zip_path: Path) -> None:
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for rank in ranks:
+            for name in (
+                f"rank{rank}_classic_per_iteration_summary.csv",
+                f"rank{rank}_gpu_memory.log",
+            ):
+                path = engine / name
+                if path.is_file():
+                    zf.write(path, arcname=name)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Export per-rank per-iteration CSV + GPU logs for Notion."
+    )
+    parser.add_argument(
+        "run_dir",
+        type=Path,
+        help="Hydra run dir (contains engine/ and slurm-*.out)",
+    )
+    parser.add_argument(
+        "--max-iter-lines",
+        type=int,
+        default=None,
+        help="Truncate per-iteration CSV (keeps head + tail). Default: full file.",
+    )
+    parser.add_argument(
+        "--max-gpu-lines",
+        type=int,
+        default=200,
+        help="Truncate GPU log lines (default 200; full iter CSV, trimmed GPU).",
+    )
+    parser.add_argument(
+        "--no-zip",
+        action="store_true",
+        help="Skip writing classic_per_rank_logs.zip",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=None,
+        help="Notion text path (default: engine/classic_per_rank_notion.txt)",
+    )
+    args = parser.parse_args(argv)
+
+    run_dir = args.run_dir.resolve()
+    engine = _find_engine_dir(run_dir)
+    ranks = _detect_ranks(engine)
+    if not ranks:
+        raise SystemExit(f"No rank*_classic_per_iteration_summary.csv or gpu logs in {engine}")
+
+    notion_path = args.output or (engine / "classic_per_rank_notion.txt")
+    notion_text = build_notion_text(
+        engine,
+        ranks,
+        max_iter_lines=args.max_iter_lines,
+        max_gpu_lines=args.max_gpu_lines,
+    )
+    notion_path.write_text(notion_text, encoding="utf-8")
+
+    print(f"Wrote {notion_path} ({len(ranks)} ranks: {ranks})", flush=True)
+
+    if not args.no_zip:
+        zip_path = engine / "classic_per_rank_logs.zip"
+        write_zip(engine, ranks, zip_path)
+        print(f"Wrote {zip_path}", flush=True)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/write_classic_per_round_summary.py
+++ b/scripts/write_classic_per_round_summary.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Regenerate classic_per_round_summary.* from an existing Hydra run directory."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+from src.omnifed.summary.slurm_per_round import write_classic_slurm_per_round_summary
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description="Build classic centralized per-round summary CSV from Node0 metrics."
+    )
+    p.add_argument(
+        "hydra_out_dir",
+        help="Hydra run dir (contains Node0.* and engine/node_results/)",
+    )
+    p.add_argument("--world-size", type=int, default=7)
+    p.add_argument("--rpc-server-rank", type=int, default=0)
+    args = p.parse_args()
+
+    out = write_classic_slurm_per_round_summary(
+        os.path.abspath(args.hydra_out_dir),
+        world_size=int(args.world_size),
+        rpc_server_rank=int(args.rpc_server_rank),
+        rank_writer=1,
+    )
+    if out is None:
+        raise SystemExit(1)
+    print(f"Wrote summary under {out}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/omnifed/classic/__init__.py
+++ b/src/omnifed/classic/__init__.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2025, Oak Ridge National Laboratory.  All rights reserved.
+
+from src.omnifed.classic.classic_grad_config import (
+    classic_communicate_params_from_cfg,
+    format_classic_grad_policy,
+)
+
+__all__ = [
+    "classic_communicate_params_from_cfg",
+    "format_classic_grad_policy",
+]

--- a/src/omnifed/classic/classic_grad_config.py
+++ b/src/omnifed/classic/classic_grad_config.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2025, Oak Ridge National Laboratory.  All rights reserved.
+
+"""Classic centralized Slurm: gradient vs parameter aggregation."""
+
+from __future__ import annotations
+
+from typing import Union
+
+from omegaconf import DictConfig, OmegaConf
+
+from src.omnifed.hybrid.hybrid_aggregate_config import normalize_aggregate_payload
+
+_CLASSIC_AGGREGATE_KEY = "engine.classic.aggregate_payload"
+
+
+def classic_aggregate_payload_from_cfg(cfg: Union[DictConfig, object]):
+    raw = OmegaConf.select(cfg, _CLASSIC_AGGREGATE_KEY, default="params")
+    return normalize_aggregate_payload(raw)
+
+
+def classic_communicate_params_from_cfg(cfg: Union[DictConfig, object]) -> bool:
+    return classic_aggregate_payload_from_cfg(cfg) != "gradients"
+
+
+def format_classic_grad_policy(cfg: Union[DictConfig, object]) -> str:
+    return f"aggregate_payload={classic_aggregate_payload_from_cfg(cfg)!r}"
+
+
+__all__ = [
+    "classic_aggregate_payload_from_cfg",
+    "classic_communicate_params_from_cfg",
+    "format_classic_grad_policy",
+]

--- a/src/omnifed/classic/classic_grad_slurm.py
+++ b/src/omnifed/classic/classic_grad_slurm.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2025, Oak Ridge National Laboratory.  All rights reserved.
+
+"""Classic centralized Slurm: synchronous gradient aggregation (deferred optimizer.step)."""
+
+from __future__ import annotations
+
+import time
+import types
+
+import torch
+
+from src.omnifed.algorithm import utils
+from src.omnifed.communicator.base import AggregationOp
+from src.omnifed.hybrid.hybrid_grad_training import (
+    apply_optimizer_grads,
+    clear_model_grads,
+    grad_l2_norm,
+    normalize_accumulated_grads,
+    require_model_grads,
+)
+from src.omnifed.utils import print
+
+
+def _ensure_model_grad_tensors(model) -> None:
+    with torch.no_grad():
+        for param in model.parameters():
+            if param.requires_grad and param.grad is None:
+                param.grad = torch.zeros_like(param.data)
+
+
+def install_classic_grad_slurm_sync(algorithm, *, local_comm) -> None:
+    """
+    Synchronous gradient FedAvg: backward locally, aggregate grads, then optimizer.step().
+
+    Use with ``algorithm/schedules/aggregation: batch_end`` for per-minibatch sync.
+    """
+    algorithm._classic_communicate_params = False
+    algorithm._classic_local_comm = local_comm
+
+    base_round_start = algorithm._round_start
+    base_round_end = getattr(algorithm, "_round_end", lambda self: None)
+
+    def _round_start_grad(self) -> None:
+        opt = self._BaseAlgorithm__local_optimizer
+        if opt is not None:
+            opt.zero_grad(set_to_none=True)
+        self._classic_batches_since_sync = 0
+        base_round_start()
+
+    def _round_end_with_eval(self) -> None:
+        if getattr(self.datamodule, "eval", None) is not None:
+            print(
+                f"Round-end evaluation @ {self.progress_info_str}",
+                flush=True,
+            )
+            self._BaseAlgorithm__eval_epoch(self.local_model)
+        base_round_end()
+
+    def _train_batch_grad(self, batch):
+        loss = self._compute_loss(batch)
+        self._backward_pass(loss)
+        self._classic_batches_since_sync = (
+            int(getattr(self, "_classic_batches_since_sync", 0)) + 1
+        )
+        metrics = {
+            "loss": loss.detach().item(),
+            "grad_norm": grad_l2_norm(self.local_model),
+        }
+        train_state = getattr(self, "_summary_iter_train", None)
+        if train_state is not None:
+            train_state.update(metrics)
+        return metrics
+
+    def _aggregate_within_group_sync_grads(self, comm, weight):
+        nb = int(getattr(self, "_classic_batches_since_sync", 0))
+        if nb < 1:
+            _ensure_model_grad_tensors(self.local_model)
+        else:
+            normalize_accumulated_grads(self.local_model, nb)
+            utils.scale_grads(self.local_model, weight)
+        require_model_grads(self.local_model)
+        _set_comm_sample_count(comm, int(self._BaseAlgorithm__num_samples_trained))
+        comm.aggregate(self.local_model, AggregationOp.SUM)
+        return self.local_model
+
+    def _optimizer_step_deferred(self) -> None:
+        return
+
+    def _classic_grad__sync_comm(self) -> None:
+        dev = next(self.local_model.parameters()).device
+        sync_bucket = getattr(self, "_summary_iter_sync", None)
+
+        t0 = time.perf_counter()
+        with self.track_model_operation("grpc_agg_sample"):
+            _set_comm_sample_count(self.local_comm, 0)
+            group_total_samples = self.local_comm.aggregate(
+                torch.tensor(
+                    [self._BaseAlgorithm__num_samples_trained],
+                    dtype=torch.float32,
+                    device=dev,
+                ),
+                reduction=AggregationOp.SUM,
+            ).item()
+        if sync_bucket is not None:
+            sync_bucket["grpc_agg_sample_time"] = time.perf_counter() - t0
+
+        within_group_weight = self._BaseAlgorithm__num_samples_trained / max(
+            group_total_samples, 1
+        )
+
+        t0 = time.perf_counter()
+        with self.track_model_operation("grpc_agg_grad"):
+            self.local_model = self._aggregate_within_group(
+                self.local_comm, within_group_weight
+            )
+        if sync_bucket is not None:
+            sync_bucket["grpc_agg_grad_time"] = time.perf_counter() - t0
+
+        t0 = time.perf_counter()
+        with self.track_model_operation("grad_apply"):
+            opt = self._BaseAlgorithm__local_optimizer
+            if opt is None:
+                raise RuntimeError(
+                    "Classic grad apply: optimizer missing before optimizer.step()."
+                )
+            apply_optimizer_grads(self.local_model, opt)
+        if sync_bucket is not None:
+            sync_bucket["grad_apply_time"] = time.perf_counter() - t0
+
+        t0 = time.perf_counter()
+        with self.track_model_operation("grpc_agg_bn"):
+            _aggregate_buffers_sample_weighted(
+                self.local_model,
+                self.local_comm,
+                within_group_weight,
+            )
+        if sync_bucket is not None:
+            sync_bucket["grpc_agg_bn_time"] = time.perf_counter() - t0
+
+        # Backward-compatible aggregate for per-round summary (sum of gRPC sync ops).
+        if sync_bucket is not None:
+            local_agg_time = sum(
+                float(sync_bucket.get(k, 0.0) or 0.0)
+                for k in (
+                    "grpc_agg_sample_time",
+                    "grpc_agg_grad_time",
+                    "grpc_agg_bn_time",
+                )
+            )
+            self.log_metric("local_agg_time", local_agg_time)
+
+        clear_model_grads(
+            self.local_model,
+            optimizer=self._BaseAlgorithm__local_optimizer,
+        )
+        self._classic_batches_since_sync = 0
+
+    algorithm._round_start = types.MethodType(_round_start_grad, algorithm)
+    algorithm._round_end = types.MethodType(_round_end_with_eval, algorithm)
+    algorithm._train_batch = types.MethodType(_train_batch_grad, algorithm)
+    algorithm._optimizer_step = types.MethodType(_optimizer_step_deferred, algorithm)
+    algorithm._aggregate_within_group = types.MethodType(
+        _aggregate_within_group_sync_grads, algorithm
+    )
+    algorithm._BaseAlgorithm__sync_comm = types.MethodType(
+        _classic_grad__sync_comm, algorithm
+    )
+
+    print(
+        "[classic] synchronous gradient aggregation (deferred optimizer.step)",
+        flush=True,
+    )
+
+
+def _set_comm_sample_count(comm, num_samples: int) -> None:
+    setter = getattr(comm, "set_aggregation_num_samples", None)
+    if setter is not None:
+        setter(max(int(num_samples), 0))
+
+
+def _aggregate_buffers_sample_weighted(model, comm, weight: float) -> None:
+    buf_dict: dict[str, torch.Tensor] = {}
+    with torch.no_grad():
+        for name, buf in model.named_buffers():
+            if buf is None or not buf.dtype.is_floating_point:
+                continue
+            buf_dict[name] = buf.data.detach().clone().mul(weight)
+    if not buf_dict:
+        return
+    _set_comm_sample_count(comm, 0)
+    agg = comm.aggregate(buf_dict, AggregationOp.SUM)
+    with torch.no_grad():
+        for name, buf in model.named_buffers():
+            if name in agg:
+                buf.data.copy_(agg[name].to(buf.device))
+
+
+__all__ = ["install_classic_grad_slurm_sync"]

--- a/src/omnifed/classic/classic_param_slurm.py
+++ b/src/omnifed/classic/classic_param_slurm.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2025, Oak Ridge National Laboratory.  All rights reserved.
+
+"""Classic centralized Slurm: synchronous parameter aggregation (optimizer.step before sync)."""
+
+from __future__ import annotations
+
+import time
+import types
+
+import torch
+
+from src.omnifed.classic.classic_grad_slurm import _set_comm_sample_count
+from src.omnifed.communicator.base import AggregationOp
+from src.omnifed.utils import print
+
+
+def install_classic_param_slurm_sync(algorithm, *, local_comm) -> None:
+    """
+    Synchronous param FedAvg: local optimizer.step, then aggregate model params.
+
+    Per-iter CSV column mapping (shared header with grad runs):
+    - ``grpc_agg_sample_s`` — sample-count SUM
+    - ``grpc_agg_grad_s`` — param payload SUM (weights + BN buffers)
+    - ``grpc_agg_bn_s`` / ``grad_apply_s`` — unused (empty) on param track
+
+    Optional Top-K / QSGD: wire compressors on ``local_comm`` and call
+    ``set_aggregation_num_samples`` before param aggregate (same gate as grad).
+    BN buffers are still included in the payload until a dense-BN split lands.
+    """
+    algorithm._classic_communicate_params = True
+    algorithm._classic_local_comm = local_comm
+
+    base_round_end = getattr(algorithm, "_round_end", lambda self: None)
+    base_train_batch = algorithm._train_batch
+
+    def _round_end_with_eval(self) -> None:
+        if getattr(self.datamodule, "eval", None) is not None:
+            print(
+                f"Round-end evaluation @ {self.progress_info_str}",
+                flush=True,
+            )
+            self._BaseAlgorithm__eval_epoch(self.local_model)
+        base_round_end()
+
+    def _train_batch_param(self, batch):
+        metrics = base_train_batch(batch)
+        train_state = getattr(self, "_summary_iter_train", None)
+        if train_state is not None:
+            train_state.update(metrics)
+        return metrics
+
+    def _classic_param__sync_comm(self) -> None:
+        dev = next(self.local_model.parameters()).device
+        sync_bucket = getattr(self, "_summary_iter_sync", None)
+
+        t0 = time.perf_counter()
+        with self.track_model_operation("grpc_agg_sample"):
+            _set_comm_sample_count(self.local_comm, 0)
+            group_total_samples = self.local_comm.aggregate(
+                torch.tensor(
+                    [self._BaseAlgorithm__num_samples_trained],
+                    dtype=torch.float32,
+                    device=dev,
+                ),
+                reduction=AggregationOp.SUM,
+            ).item()
+        if sync_bucket is not None:
+            sync_bucket["grpc_agg_sample_time"] = time.perf_counter() - t0
+
+        within_group_weight = self._BaseAlgorithm__num_samples_trained / max(
+            group_total_samples, 1
+        )
+
+        t0 = time.perf_counter()
+        with self.track_model_operation("grpc_agg_param"):
+            _set_comm_sample_count(
+                self.local_comm, int(self._BaseAlgorithm__num_samples_trained)
+            )
+            self.local_model = self._aggregate_within_group(
+                self.local_comm, within_group_weight
+            )
+        if sync_bucket is not None:
+            # Reuse grad column for param payload timing (see module docstring).
+            sync_bucket["grpc_agg_grad_time"] = time.perf_counter() - t0
+
+        if sync_bucket is not None:
+            local_agg_time = sum(
+                float(sync_bucket.get(k, 0.0) or 0.0)
+                for k in ("grpc_agg_sample_time", "grpc_agg_grad_time")
+            )
+            self.log_metric("local_agg_time", local_agg_time)
+
+    algorithm._round_end = types.MethodType(_round_end_with_eval, algorithm)
+    algorithm._train_batch = types.MethodType(_train_batch_param, algorithm)
+    algorithm._BaseAlgorithm__sync_comm = types.MethodType(
+        _classic_param__sync_comm, algorithm
+    )
+
+    print(
+        "[classic] synchronous parameter aggregation (optimizer.step before sync)",
+        flush=True,
+    )
+
+
+__all__ = ["install_classic_param_slurm_sync"]

--- a/src/omnifed/communicator/_configs.py
+++ b/src/omnifed/communicator/_configs.py
@@ -51,6 +51,9 @@ class TorchDistCommunicatorConfig(BaseCommunicatorConfig):
     # Retry settings
     max_retries: int = 5
 
+    # True: all-reduce parameters (+ buffers). False: all-reduce gradients (classic sync grad).
+    communicate_params: bool = True
+
 
 @dataclass
 class GrpcCommunicatorConfig(BaseCommunicatorConfig):

--- a/src/omnifed/communicator/compression/quantization.py
+++ b/src/omnifed/communicator/compression/quantization.py
@@ -12,167 +12,99 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""QSGD quantization for classic centralized gRPC (sync grad path)."""
+
+from __future__ import annotations
+
 import torch
 
 from . import Compression
 
-# ======================================================================================
+QSGD_COMPRESSION_NAME = "QSGDQuantCompression"
 
-def should_compress_tensor(x):
-    return (
-        isinstance(x, torch.Tensor)
-        and x.is_floating_point()
-        and x.numel() > 0
-    )
 
-def choose_qsgd_storage_width(levels):
+def should_compress_tensor(x: torch.Tensor) -> bool:
+    return isinstance(x, torch.Tensor) and x.is_floating_point() and x.numel() > 0
+
+
+def choose_qsgd_storage_width(levels: int) -> tuple[int, torch.dtype]:
     if levels <= torch.iinfo(torch.int8).max:
         return 8, torch.int8
     return 32, torch.int32
 
+
 class QSGDQuantCompression(Compression):
     """
-    QSGD implementation based on the paper:
-    [QSGD: Communication-Efficient SGD via Gradient Quantization and Encoding](https://arxiv.org/abs/1610.02132)
-    | Alistarh et al. | 2017
+    QSGD implementation based on:
+    QSGD: Communication-Efficient SGD via Gradient Quantization and Encoding
+    (Alistarh et al., 2017)
     """
 
-    def __init__(self, bit_width=8, device="cpu"):
-        self.s = bit_width  # Number of quantization levels = 2^s
-        self.device = device
+    def __init__(self, bit_width: int = 8, device: torch.device | str = "cpu"):
+        super().__init__()
+        self.s = int(bit_width)
+        self.device = torch.device(device)
 
-    def quantize_vector(self, v):
+    def quantize_vector(self, v: torch.Tensor):
         """
-        QSGD quantization function Q_s(v) as defined in Algorithm 1 of the paper
-
-        Args:
-            v: Input vector to quantize
-
-        Returns:
-            Quantized vector with same expected value as input
+        Stochastic QSGD Q_s(v). Returns signed_levels, norm_v, width, levels.
+        width/levels/norm are -1 when passthrough (empty or zero norm).
         """
         if v.numel() == 0:
-            return v, v, -1, -1
+            return v, -1, -1, -1
 
-        # Step 1: Compute the norm
         norm_v = torch.norm(v).item()
-
         if norm_v == 0:
-            return torch.zeros_like(v), torch.zeros_like(v), -1, -1
+            return torch.zeros_like(v), -1, -1, -1
 
-        # Step 2: Normalize the vector
         v_normalized = v / norm_v
-
-        # Step 3: Component-wise quantization
-        # For each component v_i, compute sign and magnitude
         signs = torch.sign(v_normalized)
         abs_v = torch.abs(v_normalized)
-
-        # Quantization levels from 0 to s
         levels = 2**self.s
 
-        # Stochastic quantization
-        # ξ_i = l/s where l is chosen such that l/s ≤ |v_i| ≤ (l+1)/s
-        # with probability proportional to the distance
         scaled_abs = abs_v * levels
-        l = torch.floor(scaled_abs).long()  # Lower quantization level
-
-        # Stochastic rounding: probability of rounding up
-        prob_round_up = scaled_abs - l.float()
-        random_vals = torch.rand_like(prob_round_up)
-        round_up = (random_vals < prob_round_up).long()
-
-        # Final quantization levels
-        quantized_levels = l + round_up
-        quantized_levels = torch.clamp(quantized_levels, 0, levels)
+        lower = torch.floor(scaled_abs).long()
+        prob_round_up = scaled_abs - lower.float()
+        round_up = (torch.rand_like(prob_round_up) < prob_round_up).long()
+        quantized_levels = torch.clamp(lower + round_up, 0, levels)
 
         signed_levels = signs.long() * quantized_levels
-        # width = 8
-        # if levels <= 127:
-        #     signed_levels = signed_levels.to(torch.int8)
-        # else:
-        #     signed_levels = signed_levels.to(torch.int16)
-        #     width = 16
         width, storage_dtype = choose_qsgd_storage_width(levels)
-
         signed_levels = signed_levels.to(storage_dtype)
-
         return signed_levels, norm_v, width, levels
 
-        # # Convert back to quantized values
-        # quantized_abs = quantized_levels.float() / levels
-        # quantized_normalized = signs * quantized_abs
+    def _do_compress(self, tensor: torch.Tensor):
+        flat = tensor.flatten()
+        signed_levels, norm, width, levels = self.quantize_vector(flat)
+        if width == -1 or levels == -1 or norm == -1:
+            return tensor, -1, -1, -1
+        signed_levels = signed_levels.reshape(tensor.shape).to(tensor.device)
+        return signed_levels, norm, width, levels
 
-        # # Scale back by the norm
-        # quantized = norm_v * quantized_normalized
-
-        # return quantized, norm_v
-    
-    def __do_compress(self, gradients):
-        # quantized_grads = []
-        # norms = []
-
-        # for grad in gradients:
-        if gradients is None:
-            return None, None, -1, -1
-        else:
-            flat_grad = gradients.flatten()
-            q_grad, norm, width, levels = self.quantize_vector(flat_grad)
-            
-
-            # print("[qsgd] after quantize_vector")
-            # print(f"  flat_grad type: {type(flat_grad)}")
-            # print(f"  flat_grad dtype: {getattr(flat_grad, 'dtype', None)}")
-            # print(f"  flat_grad device: {getattr(flat_grad, 'device', None)}")
-            # print(f"  flat_grad shape: {getattr(flat_grad, 'shape', None)}")
-            # print(f"  flat_grad numel: {flat_grad.numel() if isinstance(flat_grad, torch.Tensor) else 'N/A'}")
-            # print(f"  flat_grad element_size: {flat_grad.element_size() if isinstance(flat_grad, torch.Tensor) else 'N/A'}")
-
-            # print(f"  q_grad type: {type(q_grad)}")
-            # print(f"  q_grad dtype: {getattr(q_grad, 'dtype', None)}")
-            # print(f"  q_grad device: {getattr(q_grad, 'device', None)}")
-            # print(f"  q_grad shape: {getattr(q_grad, 'shape', None)}")
-            # print(f"  q_grad numel: {q_grad.numel() if isinstance(q_grad, torch.Tensor) else 'N/A'}")
-            # print(f"  q_grad element_size: {q_grad.element_size() if isinstance(q_grad, torch.Tensor) else 'N/A'}")
-
-            # print(f"  norm type: {type(norm)}")
-            # print(f"  norm dtype: {getattr(norm, 'dtype', None)}")
-            # print(f"  norm device: {getattr(norm, 'device', None)}")
-            # print(f"  norm shape: {getattr(norm, 'shape', None)}")
-
-            # if isinstance(q_grad, torch.Tensor):
-            #     print(f"  q_grad min: {q_grad.min().item() if q_grad.numel() > 0 else 'empty'}")
-            #     print(f"  q_grad max: {q_grad.max().item() if q_grad.numel() > 0 else 'empty'}")
-            #     print(f"  q_grad expected bytes: {q_grad.numel() * q_grad.element_size()}")
-
-            q_grad = q_grad.reshape(gradients.shape).to(gradients.device)
-
-            return q_grad, norm, width, levels
-
-            # print("[qsgd] after reshape + device move")
-            # print(f"  gradients shape: {gradients.shape}")
-            # print(f"  gradients dtype: {gradients.dtype}")
-            # print(f"  gradients device: {gradients.device}")
-            # print(f"  q_grad dtype: {q_grad.dtype}")
-            # print(f"  q_grad device: {q_grad.device}")
-            # print(f"  q_grad shape: {q_grad.shape}")
-            # print(f"  q_grad element_size: {q_grad.element_size()}")
-            # print(f"  q_grad expected bytes: {q_grad.numel() * q_grad.element_size()}")
-            # norms.append(norm)
-
-        # print(f"quantized_grads = {quantized_grads}")
-        # # print(f"quantized_grads type = {type(quantized_grads)}")
-        # print(f"norms = {norms}")
-
-    def compress(self, tensor, name=''):
-        """
-        Compress tensors using proper QSGD
-        """
-        # print(f"tensor = {tensor}")
+    def compress(self, tensor: torch.Tensor, name: str = ""):
+        del name
         if not should_compress_tensor(tensor):
             return tensor, -1, -1, -1
-        return self.__do_compress(tensor)
+        return self._do_compress(tensor)
+
+    @staticmethod
+    def decompress_quantized(
+        signed_levels: torch.Tensor,
+        norm: float,
+        levels: int,
+        shape: torch.Size | tuple[int, ...],
+    ) -> torch.Tensor:
+        """Inverse of QSGD encode: norm * signed_level / levels."""
+        if levels <= 0 or norm is None or norm == -1:
+            return signed_levels.float() if signed_levels.is_floating_point() else signed_levels
+        flat = signed_levels.float().reshape(-1)
+        restored = float(norm) * flat / float(levels)
+        return restored.reshape(shape)
+
+    def decompress(self, tensors, ctx):
+        norm, _width, levels, shape = ctx
+        signed_levels = tensors[0] if isinstance(tensors, (tuple, list)) else tensors
+        return self.decompress_quantized(signed_levels, norm, levels, shape)
 
 
-
-_quantized_compression_ = ["QSGDQuantCompression"]
+_quantized_compression_ = [QSGD_COMPRESSION_NAME]

--- a/src/omnifed/communicator/compression/torchdist_collectives.py
+++ b/src/omnifed/communicator/compression/torchdist_collectives.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2025, Oak Ridge National Laboratory.  All rights reserved.
+
+"""TorchDist collective helpers for compressed aggregation (Top-K, QSGD)."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import torch
+import torch.distributed as dist
+
+from src.omnifed.summary.per_iteration import accumulate_iter_comm
+
+from .quantization import QSGDQuantCompression
+from .sparsification import TopKCompression
+
+
+def _record_comm_time(logger: Any, key: str, t0: float) -> None:
+    if logger is not None:
+        accumulate_iter_comm(logger, key, time.perf_counter() - t0)
+
+
+def all_gather_sparse_sum(
+    values: torch.Tensor,
+    indices: torch.Tensor,
+    *,
+    numel: int,
+    world_size: int,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Pad + ``all_gather`` Top-K payloads, then SUM into a dense vector."""
+    tensor_size = int(values.numel())
+    size_tensor = torch.tensor([tensor_size], device=device, dtype=torch.long)
+    size_list = [torch.zeros(1, dtype=torch.long, device=device) for _ in range(world_size)]
+    dist.all_gather(size_list, size_tensor)
+    sizes = [int(s.item()) for s in size_list]
+    max_size = max(sizes) if sizes else 0
+    if max_size == 0:
+        return torch.zeros(numel, dtype=dtype, device=device)
+
+    val_buf = values
+    ix_buf = indices.to(device=device, dtype=torch.long)
+    if tensor_size < max_size:
+        val_pad = torch.zeros(max_size - tensor_size, dtype=values.dtype, device=device)
+        ix_pad = torch.zeros(max_size - tensor_size, dtype=torch.long, device=device)
+        val_buf = torch.cat((val_buf, val_pad), dim=0)
+        ix_buf = torch.cat((ix_buf, ix_pad), dim=0)
+
+    val_list = [
+        torch.zeros(max_size, dtype=values.dtype, device=device) for _ in range(world_size)
+    ]
+    ix_list = [
+        torch.zeros(max_size, dtype=torch.long, device=device) for _ in range(world_size)
+    ]
+    dist.all_gather(val_list, val_buf)
+    dist.all_gather(ix_list, ix_buf)
+
+    out = torch.zeros(numel, dtype=dtype, device=device)
+    for r, n in enumerate(sizes):
+        if n <= 0:
+            continue
+        out.index_add_(0, ix_list[r][:n], val_list[r][:n].to(dtype=dtype))
+    return out
+
+
+def aggregate_topk_tensor(
+    compressor: TopKCompression,
+    tensor: torch.Tensor,
+    *,
+    name: str,
+    world_size: int,
+    logger: Any = None,
+) -> torch.Tensor:
+    """Top-K compress on device, sparse ``all_gather``, SUM (matches gRPC server SUM)."""
+    device = tensor.device
+    t0 = time.perf_counter()
+    (values, indices), ctx = compressor.compress(tensor, name)
+    _record_comm_time(logger, "grpc_compress_s", t0)
+
+    numel, shape = ctx
+    t0 = time.perf_counter()
+    dense = all_gather_sparse_sum(
+        values,
+        indices,
+        numel=numel,
+        world_size=world_size,
+        device=device,
+        dtype=tensor.dtype,
+    ).view(shape)
+    _record_comm_time(logger, "grpc_decompress_s", t0)
+    return dense
+
+
+def aggregate_qsgd_tensor(
+    compressor: QSGDQuantCompression,
+    tensor: torch.Tensor,
+    *,
+    name: str,
+    op: dist.ReduceOp,
+    logger: Any = None,
+) -> torch.Tensor:
+    """QSGD quantize on device, dequantize locally, dense ``all_reduce`` SUM."""
+    t0 = time.perf_counter()
+    signed, norm, width, levels = compressor.compress(tensor, name)
+    _record_comm_time(logger, "grpc_compress_s", t0)
+
+    if width == -1 or levels == -1 or norm == -1:
+        dist.all_reduce(tensor, op=op)
+        return tensor
+
+    t0 = time.perf_counter()
+    dense = QSGDQuantCompression.decompress_quantized(
+        signed, norm, levels, tensor.shape
+    ).to(device=tensor.device, dtype=tensor.dtype)
+    _record_comm_time(logger, "grpc_decompress_s", t0)
+
+    dist.all_reduce(dense, op=op)
+    return dense
+
+
+def is_topk_compressor(compressor: Any) -> bool:
+    return isinstance(compressor, TopKCompression)
+
+
+def is_qsgd_compressor(compressor: Any) -> bool:
+    return isinstance(compressor, QSGDQuantCompression)
+
+
+__all__ = [
+    "aggregate_qsgd_tensor",
+    "aggregate_topk_tensor",
+    "all_gather_sparse_sum",
+    "is_qsgd_compressor",
+    "is_topk_compressor",
+]

--- a/src/omnifed/communicator/grpc.proto
+++ b/src/omnifed/communicator/grpc.proto
@@ -45,6 +45,7 @@ message AggregationRequest {
     string client_id = 1;
     TensorDict tensor_dict = 2;
     string reduction_type = 3;  // "sum" or "mean"
+    int32 num_samples = 4;  // client sample count for sample-weighted grad/param aggregation
 }
 
 // Generic tensor response (used for both broadcast and aggregation results)
@@ -77,4 +78,9 @@ message TensorEntry {
     repeated int32 index_shape = 9; // The index shape
     string index_dtype = 10;
     repeated int32 original_shape = 11; // The original data shape
+    // QSGD (classic centralized sync grad): norm + quant metadata
+    bytes meta_tensor = 12;
+    string meta_dtype = 13;
+    int32 width = 14;
+    int32 level = 15;
 }

--- a/src/omnifed/communicator/grpc.py
+++ b/src/omnifed/communicator/grpc.py
@@ -54,24 +54,31 @@ class GrpcCommunicator(BaseCommunicator):
         retry_delay: float = 5.0,
         max_retries: int = 5,
         client_compressor=None,
-        server_compressor=None
+        server_compressor=None,
+        communicate_params: bool = True,
+        normalize_by_total_samples: bool = False,
+        backend: object = None,
+        **kwargs: object,
     ) -> None:
         """
         Initialize gRPC-based federated learning communicator.
 
-        Args:
-            rank: Process rank (0 becomes server, others become clients)
-            world_size: Total number of participants in FL experiment
-            master_addr: gRPC server address (rank 0 listens here)
-            master_port: gRPC server port
-            max_workers: Thread pool size for gRPC server
-            max_send_message_length: Maximum outbound message size in bytes
-            max_receive_message_length: Maximum inbound message size in bytes
-            aggregation_timeout: Server timeout waiting for all clients (seconds)
-            client_timeout: Client timeout waiting for aggregation result (seconds)
-            retry_delay: Seconds between connection retry attempts
-            max_retries: Maximum connection retry attempts
+        ``backend`` is accepted (and ignored) when Hydra merges TorchDist leftovers.
         """
+        if backend is not None:
+            warnings.warn(
+                f"GrpcCommunicator ignores TorchDist-only argument backend={backend!r}",
+                stacklevel=2,
+            )
+        if kwargs:
+            warnings.warn(
+                f"GrpcCommunicator ignoring unused keyword arguments: {sorted(kwargs)}",
+                stacklevel=2,
+            )
+
+        # slurm_worker uses ``backend`` only to pick CUDA vs CPU (no torch.distributed PG).
+        self.backend = "nccl" if torch.cuda.is_available() else "gloo"
+
         super().__init__(rank, world_size, master_addr, master_port)
         print(f"rank={rank}/{world_size} | addr={master_addr}:{master_port}")
 
@@ -99,6 +106,9 @@ class GrpcCommunicator(BaseCommunicator):
         self._servicer = None
         self.client_compressor = client_compressor
         self.server_compressor = server_compressor
+        self.communicate_params = bool(communicate_params)
+        self.normalize_by_total_samples = bool(normalize_by_total_samples)
+        self._aggregation_num_samples = 0
 
     @property
     def client(self):
@@ -174,7 +184,12 @@ class GrpcCommunicator(BaseCommunicator):
                 ],
             )
 
-            self._servicer = GrpcServer(world_size=self.world_size, compressor=self.server_compressor)
+            self._servicer = GrpcServer(
+                world_size=self.world_size,
+                compressor=self.server_compressor,
+                communicate_params=self.communicate_params,
+                normalize_by_total_samples=self.normalize_by_total_samples,
+            )
             grpc_pb2_grpc.add_GrpcServerServicer_to_server(self._servicer, self._server)
 
             self._server.add_insecure_port(f"[::]:{self.master_port}")
@@ -190,9 +205,11 @@ class GrpcCommunicator(BaseCommunicator):
                 retry_delay=self.retry_delay,
                 max_retries=self.max_retries,
                 client_timeout=self.client_timeout,
-                compressor=self.client_compressor
+                compressor=self.client_compressor,
+                communicate_params=self.communicate_params,
             )
-    
+            if self.logger is not None:
+                self._client.set_logger(self.logger)
 
     def broadcast(
         self,
@@ -224,11 +241,14 @@ class GrpcCommunicator(BaseCommunicator):
             return self._apply_tensordict_to_msg(msg, tensordict)
 
     def set_logger(self, logger: MetricLogger):
+        """Attach metrics logger; forward to gRPC client when it exists."""
         self.logger = logger
-        try:
-            self.client.set_logger(logger)
-        except Exception:
-            pass
+        if self._client is not None:
+            self._client.set_logger(logger)
+
+    def set_aggregation_num_samples(self, num_samples: int) -> None:
+        """Sample count for the next ``aggregate()`` call (classic grad Path A/B)."""
+        self._aggregation_num_samples = max(int(num_samples), 0)
 
     def aggregate(
         self,
@@ -279,15 +299,24 @@ class GrpcCommunicator(BaseCommunicator):
             result = dict()
             for name, param in msg.named_parameters():
                 if param.requires_grad:
-                    result[name] = param.data
-            # Include buffers (batch norm stats, etc.) - only floating-point buffers
-            for name, buffer in msg.named_buffers():
-                if buffer is None:  # type: ignore
-                    warnings.warn(f"Buffer '{name}' is None, skipping serialization")
-                    continue
-                if not buffer.dtype.is_floating_point:
-                    continue  # Skip integer buffers like num_batches_tracked
-                result[name] = buffer.data
+                    if self.communicate_params:
+                        result[name] = param.data
+                    elif param.grad is not None:
+                        result[name] = param.grad.detach()
+                    else:
+                        result[name] = torch.zeros_like(param.data)
+            # Param FedAvg only: BN running stats are sample-weighted separately in
+            # grad mode (including them in SUM / sample-weighted grad agg corrupts BN).
+            if self.communicate_params:
+                for name, buffer in msg.named_buffers():
+                    if buffer is None:  # type: ignore
+                        warnings.warn(
+                            f"Buffer '{name}' is None, skipping serialization"
+                        )
+                        continue
+                    if not buffer.dtype.is_floating_point:
+                        continue  # Skip integer buffers like num_batches_tracked
+                    result[name] = buffer.data
             return result
         elif isinstance(msg, dict):
             return msg
@@ -315,26 +344,27 @@ class GrpcCommunicator(BaseCommunicator):
         """
         if isinstance(msg, nn.Module):
             with torch.no_grad():
-                # Apply parameters
+                # Apply parameters or aggregated gradients
                 for name, param in msg.named_parameters():
                     if param.requires_grad and name in tensordict:
-                        # Ensure tensor is on the same device as the parameter before copying
                         tensor = tensordict[name].to(param.device)
-                        param.data.copy_(tensor)
-                # Apply buffers (batch norm stats, etc.) - only floating-point buffers
-                for name, buffer in msg.named_buffers():
-                    if buffer is None:  # type: ignore
-                        warnings.warn(
-                            f"Buffer '{name}' is None, skipping deserialization"
-                        )
-                        continue
-                    if not buffer.dtype.is_floating_point:
-                        continue  # Skip integer buffers like num_batches_tracked
-                    if name not in tensordict:
-                        continue  # Buffer not in received data
-                    # Ensure tensor is on the same device as the buffer before copying
-                    tensor = tensordict[name].to(buffer.device)
-                    buffer.data.copy_(tensor)
+                        if self.communicate_params:
+                            param.data.copy_(tensor)
+                        else:
+                            param.grad = tensor
+                if self.communicate_params:
+                    for name, buffer in msg.named_buffers():
+                        if buffer is None:  # type: ignore
+                            warnings.warn(
+                                f"Buffer '{name}' is None, skipping deserialization"
+                            )
+                            continue
+                        if not buffer.dtype.is_floating_point:
+                            continue  # Skip integer buffers like num_batches_tracked
+                        if name not in tensordict:
+                            continue  # Buffer not in received data
+                        tensor = tensordict[name].to(buffer.device)
+                        buffer.data.copy_(tensor)
             return msg
         elif isinstance(msg, dict):
             return tensordict
@@ -359,7 +389,14 @@ class GrpcCommunicator(BaseCommunicator):
             current_session = self._submit_server_data(tensordict, reduction)
             return self._wait_for_aggregation_result(current_session)
         else:
-            self.client.submit_for_aggregation(tensordict, reduction)
+            if not self.client.submit_for_aggregation(
+                tensordict,
+                reduction,
+                num_samples=self._aggregation_num_samples,
+            ):
+                raise RuntimeError(
+                    "gRPC aggregation submit failed (see server log for session errors)"
+                )
             return self.client.get_aggregation_result()
 
     def _submit_server_data(self, tensordict: dict, reduction: AggregationOp) -> int:
@@ -386,8 +423,19 @@ class GrpcCommunicator(BaseCommunicator):
                     f"Reduction type mismatch - expected {session_state['reduction_type']}, got {reduction_str}"
                 )
 
-            # Store server data
-            session_state["data"]["server"] = tensordict
+            # Store server data (CPU tensors — server aggregates, does not train on GPU).
+            if isinstance(tensordict, dict):
+                session_state["data"]["server"] = {
+                    key: tensor.cpu() if torch.is_tensor(tensor) else tensor
+                    for key, tensor in tensordict.items()
+                }
+            elif torch.is_tensor(tensordict):
+                session_state["data"]["server"] = tensordict.cpu()
+            else:
+                session_state["data"]["server"] = tensordict
+            session_state["total_samples"] = int(
+                session_state.get("total_samples", 0)
+            ) + int(self._aggregation_num_samples)
             data_count = len(session_state["data"])
 
             print(
@@ -425,7 +473,9 @@ class GrpcCommunicator(BaseCommunicator):
         if session_state["result"] is None:
             raise RuntimeError(f"No result available for session {session_id}")
 
-        return session_state["result"]
+        result = session_state["result"]
+        self.servicer.mark_aggregation_result_delivered(session_id, "server")
+        return result
 
     def close(self):
         """

--- a/src/omnifed/communicator/grpc_client.py
+++ b/src/omnifed/communicator/grpc_client.py
@@ -23,16 +23,19 @@ import torch
 from ..utils import print
 from . import AggregationOp, grpc_pb2, grpc_pb2_grpc
 from .utils import get_msg_info, proto_to_tensordict, tensordict_to_proto, proto_to_tensordict_extended
-from .compression.sparsification import *
-from .compression.quantization import *
-from .compression.lowrank_approximation import *
-from .utils import compress_message_tensors, extract_tensordict
+from .utils import (
+    aggregation_metric_for_communicate_params,
+    compress_message_tensors,
+    compressor_proto_name,
+)
 from ..utils import MetricLogger
 # from ..logger import Baselogger
 
 from contextlib import nullcontext
 import torch
 import torch.nn as nn
+
+from src.omnifed.summary.per_iteration import accumulate_iter_comm
 
 
 
@@ -58,7 +61,8 @@ class GrpcClient:
         retry_delay: float = 5.0,
         max_retries: int = 3,
         client_timeout: float = 60,
-        compressor=None
+        compressor=None,
+        communicate_params: bool = True,
     ):
         """
         Initialize gRPC client with connection and retry settings.
@@ -86,6 +90,7 @@ class GrpcClient:
         self.client_timeout = client_timeout
         # self.compressor = TopKCompression(compress_ratio=0.01)
         self.compressor = compressor
+        self.communicate_params = bool(communicate_params)
         # self.compressor = None
         self.last_tensordict_submitted = None
         self.logger = None
@@ -96,6 +101,10 @@ class GrpcClient:
 
         # Establish connection with retry logic
         self._establish_connection()
+
+    @property
+    def aggregation_metric(self) -> str:
+        return aggregation_metric_for_communicate_params(self.communicate_params)
 
     def set_logger(self, logger: MetricLogger):
         self.logger = logger
@@ -176,50 +185,69 @@ class GrpcClient:
                 time.sleep(self.retry_delay)
 
     def submit_for_aggregation(
-        self, tensordict: Dict[str, torch.Tensor], reduction_type: AggregationOp
-    ):
+        self,
+        tensordict: Dict[str, torch.Tensor],
+        reduction_type: AggregationOp,
+        num_samples: int = 0,
+    ) -> bool:
         """
         Submit local tensors to server for distributed aggregation.
 
         Args:
             tensordict: Local tensors to contribute to aggregation
             reduction_type: SUM, MEAN, or MAX aggregation operation
+            num_samples: Training samples represented by this contribution
         """
         try:
-            # print(f"Dict to submit; type = {type(tensordict)}")
-            # _upstream_time_break_down = {}
-            # encode_start = time.time()
+            # Sample-count and BN-buffer aggs set num_samples=0; keep those payloads dense.
+            active_compressor = (
+                self.compressor if int(num_samples) > 0 else None
+            )
             ctx = self.logger.log_duration("training_compression_time") if self.logger else nullcontext()
+            t0 = time.perf_counter()
             with ctx:
-                compressed_tensordict = compress_message_tensors(tensordict, self.compressor, "grad")
-                compressor_name = None
-                if self.compressor:
-                    compressor_name = self.compressor.__class__.__name__
+                compressed_tensordict = compress_message_tensors(
+                    tensordict, active_compressor, self.aggregation_metric
+                )
+                compressor_name = compressor_proto_name(active_compressor)
                 if isinstance(tensordict, torch.Tensor):
                     compressor_name = None
                     compressed_tensordict = tensordict
                 self.last_tensordict_submitted = tensordict
                 proto_tensordict = tensordict_to_proto(compressed_tensordict, compressor_name)
+            if self.logger:
+                accumulate_iter_comm(
+                    self.logger, "grpc_compress_s", time.perf_counter() - t0
+                )
             # encode_end = time.time()
             # upload_start = time.time()
             ctx = self.logger.log_duration("training_upstream_upload_time") if self.logger else nullcontext()
+            t0 = time.perf_counter()
             with ctx:
                 request = grpc_pb2.AggregationRequest(
                     client_id=self.client_id,
                     tensor_dict=proto_tensordict,
                     reduction_type=reduction_type.value,
+                    num_samples=int(num_samples),
                 )
                 response = self.stub.SubmitForAggregation(request)
+            if self.logger:
+                accumulate_iter_comm(
+                    self.logger, "grpc_upstream_s", time.perf_counter() - t0
+                )
             # upload_end = time.time()
             # _upstream_time_break_down['upload'] = upload_end - upload_start
             # _upstream_time_break_down['encode'] = encode_end - encode_start
             # timing['upstream'].append(_upstream_time_break_down)
             if response.success:
-                print("Successfully sent local model to server")
-            else:
-                print("Submit failed")
+                payload = "params" if self.communicate_params else "grads"
+                print(f"Successfully sent local {payload} to server")
+                return True
+            print("Submit failed")
+            return False
         except grpc.RpcError as e:
             print(f"Submit exception | {e}")
+            return False
 
     def get_aggregation_result(self) -> Dict[str, torch.Tensor]:
         """
@@ -250,16 +278,29 @@ class GrpcClient:
                 request = grpc_pb2.ClientInfo(client_id=self.client_id)
                 # downstream_start = time.time()
                 ctx = self.logger.log_duration("training_downstream_download_time") if self.logger else nullcontext()
+                t0 = time.perf_counter()
                 with ctx:
                     response = self.stub.GetAggregationResult(request)
+                if self.logger:
+                    accumulate_iter_comm(
+                        self.logger, "grpc_downstream_s", time.perf_counter() - t0
+                    )
                 # downstream_end = time.time()
                 if response.is_ready:
                     # downstream_time_break_down = {'comm': [], 'decode': []}
                     # downstream_time_break_down['comm'] = downstream_end - downstream_start 
                     # decompression_start = time.time()
                     ctx = self.logger.log_duration("training_decompression_time") if self.logger else nullcontext()
+                    t0 = time.perf_counter()
                     with ctx:
-                        tensordict, is_model_communicated = proto_to_tensordict_extended(response.tensor_dict, self.last_tensordict_submitted)
+                        tensordict, is_model_communicated = proto_to_tensordict_extended(
+                            response.tensor_dict,
+                            overlay_base=None,
+                        )
+                    if self.logger:
+                        accumulate_iter_comm(
+                            self.logger, "grpc_decompress_s", time.perf_counter() - t0
+                        )
                     # decompression_end = time.time()
                     # downstream_time_break_down['decode'] = decompression_end - decompression_start
                     # timing['downstream'].append(downstream_time_break_down)

--- a/src/omnifed/communicator/grpc_pb2.py
+++ b/src/omnifed/communicator/grpc_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n#src/omnifed/communicator/grpc.proto\x12\x18src.omnifed.communicator\"\x0e\n\x0c\x45mptyRequest\"\x1f\n\nClientInfo\x12\x11\n\tclient_id\x18\x01 \x01(\t\"z\n\x12\x41ggregationRequest\x12\x11\n\tclient_id\x18\x01 \x01(\t\x12\x39\n\x0btensor_dict\x18\x02 \x01(\x0b\x32$.src.omnifed.communicator.TensorDict\x12\x16\n\x0ereduction_type\x18\x03 \x01(\t\"`\n\x11OperationResponse\x12\x39\n\x0btensor_dict\x18\x01 \x01(\x0b\x32$.src.omnifed.communicator.TensorDict\x12\x10\n\x08is_ready\x18\x02 \x01(\x08\"!\n\x0eStatusResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\"D\n\nTensorDict\x12\x36\n\x07\x65ntries\x18\x01 \x03(\x0b\x32%.src.omnifed.communicator.TensorEntry\"\xd4\x01\n\x0bTensorEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x0c\n\x04\x64\x61ta\x18\x02 \x01(\x0c\x12\r\n\x05shape\x18\x03 \x03(\x05\x12\r\n\x05\x64type\x18\x04 \x01(\t\x12\x0e\n\x06\x64\x65vice\x18\x05 \x01(\t\x12\x11\n\tdata_size\x18\x06 \x01(\x05\x12\x18\n\x10\x63ompression_type\x18\x07 \x01(\t\x12\r\n\x05index\x18\x08 \x01(\x0c\x12\x13\n\x0bindex_shape\x18\t \x03(\x05\x12\x13\n\x0bindex_dtype\x18\n \x01(\t\x12\x16\n\x0eoriginal_shape\x18\x0b \x03(\x05\x32\xb1\x03\n\nGrpcServer\x12\x66\n\x11GetBroadcastState\x12$.src.omnifed.communicator.ClientInfo\x1a+.src.omnifed.communicator.OperationResponse\x12n\n\x14SubmitForAggregation\x12,.src.omnifed.communicator.AggregationRequest\x1a(.src.omnifed.communicator.StatusResponse\x12i\n\x14GetAggregationResult\x12$.src.omnifed.communicator.ClientInfo\x1a+.src.omnifed.communicator.OperationResponse\x12`\n\x0eRegisterClient\x12$.src.omnifed.communicator.ClientInfo\x1a(.src.omnifed.communicator.StatusResponseb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n#src/omnifed/communicator/grpc.proto\x12\x18src.omnifed.communicator\"\x0e\n\x0c\x45mptyRequest\"\x1f\n\nClientInfo\x12\x11\n\tclient_id\x18\x01 \x01(\t\"\x8f\x01\n\x12\x41ggregationRequest\x12\x11\n\tclient_id\x18\x01 \x01(\t\x12\x39\n\x0btensor_dict\x18\x02 \x01(\x0b\x32$.src.omnifed.communicator.TensorDict\x12\x16\n\x0ereduction_type\x18\x03 \x01(\t\x12\x13\n\x0bnum_samples\x18\x04 \x01(\x05\"`\n\x11OperationResponse\x12\x39\n\x0btensor_dict\x18\x01 \x01(\x0b\x32$.src.omnifed.communicator.TensorDict\x12\x10\n\x08is_ready\x18\x02 \x01(\x08\"!\n\x0eStatusResponse\x12\x0f\n\x07success\x18\x01 \x01(\x08\"D\n\nTensorDict\x12\x36\n\x07\x65ntries\x18\x01 \x03(\x0b\x32%.src.omnifed.communicator.TensorEntry\"\x9b\x02\n\x0bTensorEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x0c\n\x04\x64\x61ta\x18\x02 \x01(\x0c\x12\r\n\x05shape\x18\x03 \x03(\x05\x12\r\n\x05\x64type\x18\x04 \x01(\t\x12\x0e\n\x06\x64\x65vice\x18\x05 \x01(\t\x12\x11\n\tdata_size\x18\x06 \x01(\x05\x12\x18\n\x10\x63ompression_type\x18\x07 \x01(\t\x12\r\n\x05index\x18\x08 \x01(\x0c\x12\x13\n\x0bindex_shape\x18\t \x03(\x05\x12\x13\n\x0bindex_dtype\x18\n \x01(\t\x12\x16\n\x0eoriginal_shape\x18\x0b \x03(\x05\x12\x13\n\x0bmeta_tensor\x18\x0c \x01(\x0c\x12\x12\n\nmeta_dtype\x18\r \x01(\t\x12\r\n\x05width\x18\x0e \x01(\x05\x12\r\n\x05level\x18\x0f \x01(\x05\x32\xb1\x03\n\nGrpcServer\x12\x66\n\x11GetBroadcastState\x12$.src.omnifed.communicator.ClientInfo\x1a+.src.omnifed.communicator.OperationResponse\x12n\n\x14SubmitForAggregation\x12,.src.omnifed.communicator.AggregationRequest\x1a(.src.omnifed.communicator.StatusResponse\x12i\n\x14GetAggregationResult\x12$.src.omnifed.communicator.ClientInfo\x1a+.src.omnifed.communicator.OperationResponse\x12`\n\x0eRegisterClient\x12$.src.omnifed.communicator.ClientInfo\x1a(.src.omnifed.communicator.StatusResponseb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -35,16 +35,16 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_EMPTYREQUEST']._serialized_end=79
   _globals['_CLIENTINFO']._serialized_start=81
   _globals['_CLIENTINFO']._serialized_end=112
-  _globals['_AGGREGATIONREQUEST']._serialized_start=114
-  _globals['_AGGREGATIONREQUEST']._serialized_end=236
-  _globals['_OPERATIONRESPONSE']._serialized_start=238
-  _globals['_OPERATIONRESPONSE']._serialized_end=334
-  _globals['_STATUSRESPONSE']._serialized_start=336
-  _globals['_STATUSRESPONSE']._serialized_end=369
-  _globals['_TENSORDICT']._serialized_start=371
-  _globals['_TENSORDICT']._serialized_end=439
-  _globals['_TENSORENTRY']._serialized_start=442
-  _globals['_TENSORENTRY']._serialized_end=654
-  _globals['_GRPCSERVER']._serialized_start=657
-  _globals['_GRPCSERVER']._serialized_end=1090
+  _globals['_AGGREGATIONREQUEST']._serialized_start=115
+  _globals['_AGGREGATIONREQUEST']._serialized_end=258
+  _globals['_OPERATIONRESPONSE']._serialized_start=260
+  _globals['_OPERATIONRESPONSE']._serialized_end=356
+  _globals['_STATUSRESPONSE']._serialized_start=358
+  _globals['_STATUSRESPONSE']._serialized_end=391
+  _globals['_TENSORDICT']._serialized_start=393
+  _globals['_TENSORDICT']._serialized_end=461
+  _globals['_TENSORENTRY']._serialized_start=464
+  _globals['_TENSORENTRY']._serialized_end=747
+  _globals['_GRPCSERVER']._serialized_start=750
+  _globals['_GRPCSERVER']._serialized_end=1183
 # @@protoc_insertion_point(module_scope)

--- a/src/omnifed/communicator/grpc_server.py
+++ b/src/omnifed/communicator/grpc_server.py
@@ -25,9 +25,12 @@ from ..utils import print
 from . import grpc_pb2, grpc_pb2_grpc
 from .base import AggregationOp
 from .utils import get_msg_info, proto_to_tensordict, tensordict_to_proto, proto_to_tensordict_extended
-from .compression.quantization import QSGDQuantCompression
-from .compression.sparsification import TopKCompression
-from .utils import compress_message_tensors, extract_tensordict
+from .utils import (
+    aggregation_metric_for_communicate_params,
+    compress_message_tensors,
+    compressor_proto_name,
+    extract_tensordict,
+)
 
 
 @rich.repr.auto
@@ -43,18 +46,25 @@ class GrpcServer(grpc_pb2_grpc.GrpcServerServicer):
     def __init__(
         self,
         world_size: int,
-        compressor=None
+        compressor=None,
+        communicate_params: bool = True,
+        normalize_by_total_samples: bool = False,
     ):
         """
         Initialize gRPC server for federated learning coordination.
 
         Args:
             world_size: Total number of FL participants (including server)
+            communicate_params: Aggregate model parameters when True, else gradients
+            normalize_by_total_samples: After SUM, divide by summed client ``num_samples``
+                (Path B sample-weighted grads). Path A pre-scales on clients and leaves False.
         """
         print(f"world_size={world_size}")
 
         # Core configuration
         self.world_size = world_size
+        self.communicate_params = bool(communicate_params)
+        self.normalize_by_total_samples = bool(normalize_by_total_samples)
         self.registered_clients = set()
         # self.compressor = QSGDQuantCompression()
         self.lock = threading.Lock()
@@ -63,16 +73,88 @@ class GrpcServer(grpc_pb2_grpc.GrpcServerServicer):
         # Aggregation session management
         self.current_aggregation_session = 0
         self.aggregation_state: dict[int, dict[str, Any]] = defaultdict(
-            lambda: {
-                "data": {},
-                "result": None,
-                "event": threading.Event(),
-                "reduction_type": None,
-            }
+            self._new_aggregation_session_state
         )
 
         self.compressor = compressor
         # self.compressor = None
+
+    @property
+    def aggregation_metric(self) -> str:
+        return aggregation_metric_for_communicate_params(self.communicate_params)
+
+    @staticmethod
+    def _new_aggregation_session_state() -> dict[str, Any]:
+        return {
+            "data": {},
+            "result": None,
+            "event": threading.Event(),
+            "reduction_type": None,
+            "total_samples": 0,
+            "participants": set(),
+            "results_delivered": set(),
+        }
+
+    def _session_has_participant(
+        self, session_state: dict[str, Any], participant_id: str
+    ) -> bool:
+        if participant_id in session_state["data"]:
+            return True
+        return participant_id in session_state.get("participants", ())
+
+    def _release_aggregation_inputs(self, session_state: dict[str, Any]) -> None:
+        """Drop submitted client/server tensors once aggregation result is ready."""
+        session_state["participants"] = set(session_state["data"].keys())
+        session_state["data"].clear()
+
+    def mark_aggregation_result_delivered(
+        self, session_id: int, participant_id: str
+    ) -> None:
+        """Record that a participant fetched the result; drop session when all have."""
+        with self.lock:
+            self._mark_aggregation_result_delivered_locked(session_id, participant_id)
+
+    def _mark_aggregation_result_delivered_locked(
+        self, session_id: int, participant_id: str
+    ) -> None:
+        session_state = self.aggregation_state.get(session_id)
+        if session_state is None:
+            return
+        delivered = session_state.setdefault("results_delivered", set())
+        delivered.add(participant_id)
+        participants = session_state.get("participants") or set()
+        if participants and delivered >= participants:
+            self._drop_aggregation_session(session_id)
+
+    def _drop_aggregation_session(self, session_id: int) -> None:
+        """Remove a completed aggregation session and free retained tensors."""
+        session_state = self.aggregation_state.pop(session_id, None)
+        if session_state is None:
+            return
+        session_state["data"].clear()
+        session_state["result"] = None
+        session_state["participants"] = set()
+        session_state["results_delivered"] = set()
+        session_state["event"].clear()
+        print(f"Dropped aggregation session {session_id}")
+
+    def _reset_aggregation_session(self, session_id: int) -> None:
+        """Clear a stuck/partial aggregation session so the next op can proceed."""
+        session_state = self.aggregation_state[session_id]
+        session_state["data"].clear()
+        session_state["reduction_type"] = None
+        session_state["total_samples"] = 0
+        session_state["result"] = None
+        session_state["participants"] = set()
+        session_state["results_delivered"] = set()
+        session_state["event"].clear()
+
+    def _abandon_current_session(self) -> None:
+        """Drop the active session and advance (partial MAX/SUM mix or failed submit)."""
+        sid = int(self.current_aggregation_session)
+        self._reset_aggregation_session(sid)
+        self.current_aggregation_session = sid + 1
+        print(f"Abandoned aggregation session {sid}; next session={self.current_aggregation_session}")
 
 
         # Broadcast state storage
@@ -182,12 +264,22 @@ class GrpcServer(grpc_pb2_grpc.GrpcServerServicer):
                     if reduction_type == AggregationOp.MEAN.value:
                         for tensor in aggregated_tensors.values():
                             tensor /= self.world_size
+                    elif (
+                        reduction_type == AggregationOp.SUM.value
+                        and self.normalize_by_total_samples
+                    ):
+                        total_samples = int(session_state.get("total_samples", 0))
+                        # Grad round-end submits num_samples; epoch-heartbeat scalars do not.
+                        if total_samples >= 1:
+                            for tensor in aggregated_tensors.values():
+                                tensor /= total_samples
 
                 else:
                     raise ValueError(f"Unknown reduction type: {reduction_type}")
             if is_model_communicated:
                 self.model = aggregated_tensors
             session_state["result"] = aggregated_tensors
+            self._release_aggregation_inputs(session_state)
             session_state["event"].set()
             print(
                 f"Aggregated {len(aggregated_tensors)} tensors using {reduction_type}"
@@ -232,10 +324,18 @@ class GrpcServer(grpc_pb2_grpc.GrpcServerServicer):
             session_state = self.aggregation_state[session_id]
             if session_state["result"] is not None:
                 aggregated_tensors = session_state["result"]
-                compressed_tensordict = compress_message_tensors(aggregated_tensors, self.compressor, "grad")
-                compressor_name = None
-                if self.compressor:
-                    compressor_name = self.compressor.__class__.__name__
+                # Grad sessions carry num_samples>0; sample/BN sessions stay dense.
+                active_compressor = (
+                    self.compressor
+                    if int(session_state.get("total_samples", 0)) > 0
+                    else None
+                )
+                compressed_tensordict = compress_message_tensors(
+                    aggregated_tensors,
+                    active_compressor,
+                    self.aggregation_metric,
+                )
+                compressor_name = compressor_proto_name(active_compressor)
                 if isinstance(aggregated_tensors, torch.Tensor):
                     compressor_name = None
                     compressed_tensordict = aggregated_tensors
@@ -268,20 +368,39 @@ class GrpcServer(grpc_pb2_grpc.GrpcServerServicer):
             # )
 
             try:
-                # Deserialize tensors (will be on CPU for consistent aggregation)
-                data, is_model_communicated = proto_to_tensordict_extended(request.tensor_dict, self.model)
+                # Deserialize tensors; keep on CPU on the server to avoid GPU retention.
+                data, is_model_communicated = proto_to_tensordict_extended(
+                    request.tensor_dict,
+                    overlay_base=None,
+                )
+                data = {key: tensor.cpu() for key, tensor in data.items()}
                 # print(f"Now the data is ready: data = {data}")
                 session_state = self.aggregation_state[current_session]
+
+                if (
+                    session_state["reduction_type"] is not None
+                    and session_state["reduction_type"] != request.reduction_type
+                ):
+                    if len(session_state["data"]) < self.world_size:
+                        print(
+                            f"Partial session {current_session} reduction mismatch "
+                            f"(expected={session_state['reduction_type']} "
+                            f"got={request.reduction_type}) — resetting session"
+                        )
+                        self._reset_aggregation_session(current_session)
+                    else:
+                        raise ValueError(
+                            f"Reduction mismatch | expected={session_state['reduction_type']} "
+                            f"got={request.reduction_type}"
+                        )
 
                 if session_state["reduction_type"] is None:
                     session_state["reduction_type"] = request.reduction_type
 
-                if session_state["reduction_type"] != request.reduction_type:
-                    raise ValueError(
-                        f"Reduction mismatch | expected={session_state['reduction_type']} got={request.reduction_type}"
-                    )
-
                 session_state["data"][client_id] = data
+                session_state["total_samples"] = int(
+                    session_state.get("total_samples", 0)
+                ) + int(request.num_samples)
                 data_count = len(session_state["data"])
                 print(
                     f"Received from client {client_id} ({data_count}/{self.world_size} ready)"
@@ -297,6 +416,11 @@ class GrpcServer(grpc_pb2_grpc.GrpcServerServicer):
                     f"Failed to process aggregation submission from client {client_id} | {e}",
                     RuntimeWarning,
                 )
+                try:
+                    if len(session_state.get("data", {})) < self.world_size:
+                        self._abandon_current_session()
+                except Exception:
+                    pass
                 return grpc_pb2.StatusResponse(success=False)
 
     def GetAggregationResult(self, request, context):
@@ -318,9 +442,13 @@ class GrpcServer(grpc_pb2_grpc.GrpcServerServicer):
         with self.lock:
             target_session = None
             for session_id in sorted(self.aggregation_state.keys(), reverse=True):
-                if client_id in self.aggregation_state[session_id]["data"]:
-                    target_session = session_id
-                    break
+                session_state = self.aggregation_state[session_id]
+                if not self._session_has_participant(session_state, client_id):
+                    continue
+                if client_id in session_state.get("results_delivered", set()):
+                    continue
+                target_session = session_id
+                break
             if target_session is None:
                 warnings.warn(
                     f"Client {client_id} has no data submitted for aggregation",
@@ -335,7 +463,11 @@ class GrpcServer(grpc_pb2_grpc.GrpcServerServicer):
             with self.lock:
                 if session_state["result"] is not None:
                     print(f"Sending aggregated model to client {client_id}")
-                    return self._create_aggregation_result_response(target_session)
+                    response = self._create_aggregation_result_response(target_session)
+                    self._mark_aggregation_result_delivered_locked(
+                        target_session, client_id
+                    )
+                    return response
 
             print(f"Client {client_id} waiting for aggregation to complete")
             session_state["event"].wait()
@@ -343,7 +475,11 @@ class GrpcServer(grpc_pb2_grpc.GrpcServerServicer):
             with self.lock:
                 if session_state["result"] is not None:
                     print(f"Sending aggregated model to client {client_id}")
-                    return self._create_aggregation_result_response(target_session)
+                    response = self._create_aggregation_result_response(target_session)
+                    self._mark_aggregation_result_delivered_locked(
+                        target_session, client_id
+                    )
+                    return response
             return grpc_pb2.OperationResponse(is_ready=False)
 
         except Exception as e:

--- a/src/omnifed/communicator/torchdist.py
+++ b/src/omnifed/communicator/torchdist.py
@@ -23,7 +23,23 @@ from torch import nn
 
 from ..utils import print
 from .base import AggregationOp, BaseCommunicator
+from .compression.torchdist_collectives import (
+    aggregate_qsgd_tensor,
+    aggregate_topk_tensor,
+    is_qsgd_compressor,
+    is_topk_compressor,
+)
 from .utils import get_msg_info
+
+_GRPC_CFG_ALIASES = frozenset(
+    {
+        "client_compressor",
+        "server_compressor",
+        "client_timeout",
+        "normalize_by_total_samples",
+        "retry_delay",
+    }
+)
 
 
 class InitMethod(str, Enum):
@@ -58,6 +74,11 @@ class TorchDistCommunicator(BaseCommunicator):
         sharedfile: str = "sharedfile",
         timeout: int = 600,
         max_retries: int = 5,
+        communicate_params: bool = True,
+        compressor=None,
+        client_compressor=None,
+        server_compressor=None,
+        **kwargs: object,
     ) -> None:
         """
         Initialize PyTorch distributed communicator.
@@ -73,9 +94,24 @@ class TorchDistCommunicator(BaseCommunicator):
             timeout: Process group initialization timeout (seconds)
             max_retries: Maximum initialization retry attempts
         """
+        unused = {k: v for k, v in kwargs.items() if k not in _GRPC_CFG_ALIASES}
+        if unused:
+            warnings.warn(
+                f"TorchDistCommunicator ignoring unused keyword arguments: {sorted(unused)}",
+                stacklevel=2,
+            )
+        del server_compressor
         super().__init__(rank, world_size, master_addr, master_port)
+        self.communicate_params = bool(communicate_params)
+        self.compressor = compressor if compressor is not None else client_compressor
+        self._aggregation_num_samples = 0
+        self.logger = None
+        compressor_name = (
+            type(self.compressor).__name__ if self.compressor is not None else "none"
+        )
         print(
-            f"rank={rank}/{world_size} | backend={backend} | addr={master_addr}:{master_port}"
+            f"rank={rank}/{world_size} | backend={backend} | addr={master_addr}:{master_port} | "
+            f"communicate_params={self.communicate_params} | compressor={compressor_name}"
         )
 
         # Core distributed parameters
@@ -139,6 +175,83 @@ class TorchDistCommunicator(BaseCommunicator):
         print(f"[TorchDistCommunicator->_setup] init complete rank={self.rank}")
         dist.barrier()
         print(f"[TorchDistCommunicator->_setup] barrier complete rank={self.rank}")
+
+    def set_aggregation_num_samples(self, num_samples: int) -> None:
+        """API parity with GrpcCommunicator (controls when compression applies)."""
+        self._aggregation_num_samples = max(int(num_samples), 0)
+
+    def set_logger(self, logger) -> None:
+        """Forward metric logger for per-iteration compress/decompress timings."""
+        self.logger = logger
+
+    def _active_compressor(self):
+        # Dense when no compressor, or sample/BN phases (num_samples=0).
+        # Grad (communicate_params=False) and param (True) both use compression when set.
+        if self.compressor is None or self._aggregation_num_samples <= 0:
+            return None
+        return self.compressor
+
+    def _aggregate_tensor(self, tensor: torch.Tensor, *, name: str, op: dist.ReduceOp) -> torch.Tensor:
+        active = self._active_compressor()
+        if active is None:
+            dist.all_reduce(tensor, op=op)
+            return tensor
+        if is_topk_compressor(active):
+            return aggregate_topk_tensor(
+                active,
+                tensor,
+                name=name,
+                world_size=self.world_size,
+                logger=self.logger,
+            )
+        if is_qsgd_compressor(active):
+            return aggregate_qsgd_tensor(
+                active,
+                tensor,
+                name=name,
+                op=op,
+                logger=self.logger,
+            )
+        raise TypeError(f"Unsupported TorchDist compressor: {type(active)!r}")
+
+    @staticmethod
+    def _module_aggregate_tensor(param: nn.Parameter, *, communicate_params: bool) -> torch.Tensor:
+        if communicate_params:
+            return param.data
+        if param.grad is not None:
+            return param.grad
+        return torch.zeros_like(param.data)
+
+    @staticmethod
+    def _apply_module_aggregate_tensor(
+        param: nn.Parameter, tensor: torch.Tensor, *, communicate_params: bool
+    ) -> None:
+        if communicate_params:
+            param.data.copy_(tensor.to(param.device))
+        else:
+            param.grad = tensor.to(param.device)
+
+    def _all_reduce_module(self, msg: nn.Module, op: dist.ReduceOp) -> None:
+        with torch.no_grad():
+            for pname, param in msg.named_parameters():
+                if not param.requires_grad:
+                    continue
+                tensor = self._module_aggregate_tensor(
+                    param, communicate_params=self.communicate_params
+                )
+                reduced = self._aggregate_tensor(tensor, name=pname, op=op)
+                self._apply_module_aggregate_tensor(
+                    param, reduced, communicate_params=self.communicate_params
+                )
+            if self.communicate_params:
+                for name, buffer in msg.named_buffers():
+                    if buffer is None:  # type: ignore
+                        warnings.warn(f"Buffer '{name}' is None, skipping aggregation")
+                        continue
+                    if not buffer.dtype.is_floating_point:
+                        continue
+                    reduced = self._aggregate_tensor(buffer.data, name=name, op=op)
+                    buffer.data.copy_(reduced.to(buffer.device))
 
     def broadcast(
         self,
@@ -230,25 +343,13 @@ class TorchDistCommunicator(BaseCommunicator):
 
 
         if isinstance(msg, nn.Module):
-            # Aggregate all trainable parameters
-            for _, p in msg.named_parameters():
-                if p.requires_grad:
-                    dist.all_reduce(p.data, op=op)
-            # Aggregate all buffers (batch norm stats, etc.) - only floating-point buffers
-            for name, buffer in msg.named_buffers():
-                if buffer is None:  # type: ignore
-                    warnings.warn(f"Buffer '{name}' is None, skipping aggregation")
-                    continue
-                if not buffer.dtype.is_floating_point:
-                    continue  # Skip integer buffers like num_batches_tracked
-                dist.all_reduce(buffer.data, op=op)
+            self._all_reduce_module(msg, op)
         elif isinstance(msg, dict):
-            # Aggregate each tensor in dictionary
-            for tensor in msg.values():
-                dist.all_reduce(tensor, op=op)
+            for key, tensor in msg.items():
+                reduced = self._aggregate_tensor(tensor, name=str(key), op=op)
+                msg[key] = reduced
         else:
-            # Aggregate single tensor
-            dist.all_reduce(msg, op=op)
+            msg = self._aggregate_tensor(msg, name="tensor", op=op)
 
         print(f"[aggregate] AFTER all_reduce rank={self.rank}")
 

--- a/src/omnifed/communicator/utils.py
+++ b/src/omnifed/communicator/utils.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional, Union
 import importlib
 
 import numpy as np
@@ -22,6 +22,12 @@ import torch.nn as nn
 from . import grpc_pb2
 from collections import defaultdict
 from .compression.sparsification import TopKCompression
+from .compression.quantization import QSGDQuantCompression
+
+_QSGD_NUMPY_DTYPES = {
+    8: np.int8,
+    32: np.int32,
+}
 
 
 def get_class_from_str(path: str):
@@ -29,6 +35,17 @@ def get_class_from_str(path: str):
     module = importlib.import_module(module_name)  # import the module
     cls = getattr(module, class_name)  # get class by name
     return cls
+
+
+def aggregation_metric_for_communicate_params(communicate_params: bool) -> str:
+    """Payload kind for compress/extract: ``grad`` or ``param``."""
+    return "param" if communicate_params else "grad"
+
+
+def compressor_proto_name(compressor) -> Optional[str]:
+    if compressor is None:
+        return None
+    return compressor.__class__.__name__
 
 
 def extract_tensordict(msg, aggregation_metric):
@@ -39,18 +56,18 @@ def extract_tensordict(msg, aggregation_metric):
         return {"__tensor__": msg}
 
     elif isinstance(msg, dict):
-        # assume dict[str, Tensor]
         tensordict = {}
-        # print(msg)
-        for name, param in msg.items():
-            # print(f"name = {name} , param = {param}")
+        for name, value in msg.items():
+            if isinstance(value, torch.Tensor):
+                tensordict[name] = value
+                continue
             if aggregation_metric == "grad":
-                if param.grad is not None:
-                    tensordict[name] = param.grad
+                if value.grad is not None:
+                    tensordict[name] = value.grad
                 else:
-                    tensordict[name] = param.data
+                    tensordict[name] = value.data
             elif aggregation_metric == "param":
-                tensordict[name] = param.data
+                tensordict[name] = value.data
             else:
                 raise ValueError(
                     f"Unsupported aggregation_metric: {aggregation_metric}"
@@ -78,37 +95,46 @@ def extract_tensordict(msg, aggregation_metric):
         raise TypeError("Unsupported msg type")
 
 
+def _compress_single_tensor(compressor, tensor: torch.Tensor, key: str):
+    if isinstance(compressor, TopKCompression):
+        (values, indices), ctx = compressor.compress(tensor=tensor, name=key)
+        return {
+            "values": values,
+            "indices": indices,
+            "original_shape": tensor.shape,
+            "ctx": ctx,
+        }
+    if isinstance(compressor, QSGDQuantCompression):
+        signed_levels, norm, width, levels = compressor.compress(tensor, name=key)
+        if width == -1 or levels == -1 or norm == -1:
+            return tensor
+        return {
+            "signed_levels": signed_levels,
+            "norm": norm,
+            "width": width,
+            "levels": levels,
+            "original_shape": tensor.shape,
+            "original_device": str(tensor.device),
+        }
+    raise TypeError(f"Unsupported compressor type: {type(compressor)!r}")
+
+
 def compress_message_tensors(msg, compressor, aggregation_metric):
     """
     Returns a compressed representation with 1-1 key correspondence.
     """
-    compressed = {}
-
     if compressor is None:
         return msg
 
     if isinstance(msg, torch.Tensor):
         return msg
 
-    
-
     tensordict = extract_tensordict(msg, aggregation_metric)
 
+    compressed = {}
     with torch.no_grad():
         for key, tensor in tensordict.items():
-            # print(f"key = {key}")
-            (values, indices), ctx = compressor.compress(
-                tensor=tensor,
-                name=key,
-            )
-
-            # print(f"Inside compressor: key = {key}, values = {values}, value shape = {values.shape}, indices = {indices}, index shape = {indices.shape}")
-            compressed[key] = {
-                "values": values,
-                "indices": indices,
-                "original_shape": tensor.shape,
-                "ctx": ctx,  # (numel, shape)
-            }
+            compressed[key] = _compress_single_tensor(compressor, tensor, key)
 
     return compressed
 
@@ -136,63 +162,78 @@ def tensordict_to_proto(
 
     for key, item in tensordict.items():
 
-        indices_empty = True
-        try:
-            indices_empty = item["indices"].numel() == 0
-        except Exception as e:
-            indices_empty = True
-
         # ----------------------------------------------------
         # CASE 1: COMPRESSED ENTRY (Top-K)
         # ----------------------------------------------------
-        if isinstance(item, dict) and compression_type == TopKCompression.__name__ and not indices_empty:
-            values  = item["values"]
+        if (
+            isinstance(item, dict)
+            and compression_type == TopKCompression.__name__
+            and "indices" in item
+            and item["indices"].numel() > 0
+        ):
+            values = item["values"]
             indices = item["indices"]
             numel, shape = item["ctx"]
             original_shape = item["original_shape"]
 
             original_device = str(values.device)
 
-            # print(f"TopKCompression, client submitting indices = {indices}, shape = {indices.shape}")
-            # print(f"TopKCompression, client submitting indices with type {type(indices)} and values with type {type(values)}")
-
-            values_cpu  = values.cpu()
+            values_cpu = values.cpu()
             indices_cpu = indices.cpu()
 
             data_bytes = values_cpu.numpy().tobytes()
             index_bytes = indices_cpu.numpy().tobytes()
 
-            # print(f"tensordict_to_proto =>  TopKCompression, client submitting indices_cpu = {indices_cpu}, shape = {indices_cpu.shape}")
-            # print(f"tensordict_to_proto => TopKCompression, client submitting index_bytes = {index_bytes}, shape = {indices_cpu.shape}")
-            # print(f"tensordict_to_proto => TopKCompression, client submitting index_bytes = {index_bytes}, shape = {list(indices_cpu.shape)}")
-            # print(f"tensordict_to_proto => TopKCompression, client submitting data = {values_cpu}")
-            # print(f"tensordict_to_proto => TopKCompression, client submitting data_bytes = {data_bytes}")
-            # print(f"tensordict_to_proto => TopKCompression, client submitting data_shape = {values_cpu.shape}")
-            compression_type = "TopKCompression" if len(indices_cpu) != 0 else None
-
-            # print(f"TopKCompression, index dtype is {indices_cpu.dtype}")
             entry = grpc_pb2.TensorEntry(
                 key=key,
-                data=data_bytes,                 # VALUES
-                shape=list(values_cpu.shape),               # ORIGINAL tensor shape
+                data=data_bytes,
+                shape=list(values_cpu.shape),
                 dtype=str(values_cpu.dtype),
                 device=original_device,
                 data_size=len(data_bytes),
-                compression_type=compression_type,
-                index=index_bytes,               # INDICES
-                index_shape=list(indices_cpu.shape),  # usually [k]
+                compression_type=TopKCompression.__name__,
+                index=index_bytes,
+                index_shape=list(indices_cpu.shape),
                 index_dtype=str(indices_cpu.dtype),
-                original_shape=original_shape
+                original_shape=original_shape,
             )
 
         # ----------------------------------------------------
-        # CASE 2: UNCOMPRESSED DENSE TENSOR
+        # CASE 2: COMPRESSED ENTRY (QSGD)
+        # ----------------------------------------------------
+        elif (
+            isinstance(item, dict)
+            and compression_type == QSGDQuantCompression.__name__
+            and "signed_levels" in item
+        ):
+            signed_levels = item["signed_levels"].cpu()
+            width = int(item["width"])
+            levels = int(item["levels"])
+            np_dtype = _QSGD_NUMPY_DTYPES[width]
+            levels_np = signed_levels.numpy().astype(np_dtype, copy=False)
+            data_bytes = levels_np.tobytes()
+            norm_np = np.array([float(item["norm"])], dtype=np.float32)
+
+            entry = grpc_pb2.TensorEntry(
+                key=key,
+                data=data_bytes,
+                shape=list(levels_np.shape),
+                dtype=f"torch.int{width}",
+                device=item.get("original_device", str(signed_levels.device)),
+                data_size=len(data_bytes),
+                compression_type=QSGDQuantCompression.__name__,
+                original_shape=list(item["original_shape"]),
+                meta_tensor=norm_np.tobytes(),
+                meta_dtype="torch.float32",
+                width=width,
+                level=levels,
+            )
+
+        # ----------------------------------------------------
+        # CASE 3: UNCOMPRESSED DENSE TENSOR
         # ----------------------------------------------------
         else:
-            # print(f"Inside tensordict_to_proto: No compressor found, compressor = {compression_type}")
             tensor = item
-
-            # print(f"Tensor type = {type(tensor)}, tensor = {tensor}")
 
             original_device = str(tensor.device)
             tensor_cpu = tensor.cpu()
@@ -206,10 +247,7 @@ def tensordict_to_proto(
                 dtype=str(tensor_cpu.dtype),
                 device=original_device,
                 data_size=len(data_bytes),
-                # index omitted → defaults to b""
-                # idx_shape omitted → defaults to []
             )
-
 
         entries.append(entry)
 
@@ -235,6 +273,7 @@ def proto_to_tensordict(
         "torch.float64": np.float64,
         "torch.int32": np.int32,
         "torch.int64": np.int64,
+        "torch.int8": np.int8,
         "torch.bool": np.bool_,
     }
 
@@ -273,30 +312,39 @@ def proto_to_tensordict(
 
 def proto_to_tensordict_extended(
     proto_tensordict,
-    server_model
-) -> Dict[str, torch.Tensor]:
+    overlay_base: Optional[Any] = None,
+) -> tuple[Dict[str, torch.Tensor], bool]:
     """
     Convert protobuf TensorDict back to PyTorch tensors.
-    Supports both uncompressed and Top-K compressed tensors.
+    Supports uncompressed, Top-K, and QSGD compressed tensors.
+
+    For sync grad aggregation, pass ``overlay_base=None`` so Top-K entries
+    zero-fill then scatter (full sparse message). Pass a tensor dict only when
+    intentionally overlaying sparse values onto an existing base (legacy paths).
     """
     tensordict = {}
 
     is_model_communicated = False
-
-    # print(f"Model is {server_model}")
 
     dtype_mapping = {
         "torch.float32": np.float32,
         "torch.float64": np.float64,
         "torch.int32": np.int32,
         "torch.int64": np.int64,
+        "torch.int8": np.int8,
         "torch.bool": np.bool_,
     }
 
+    overlay_lookup = None
+    if overlay_base is not None:
+        if isinstance(overlay_base, dict):
+            overlay_lookup = overlay_base
+        elif isinstance(overlay_base, nn.Module):
+            overlay_lookup = {
+                name: param.data for name, param in overlay_base.named_parameters()
+            }
+
     for entry in proto_tensordict.entries:
-        # ----------------------------
-        # Validate dtype
-        # ----------------------------
         if entry.dtype not in dtype_mapping:
             raise ValueError(
                 f"Unsupported dtype: {entry.dtype}. "
@@ -304,79 +352,68 @@ def proto_to_tensordict_extended(
             )
 
         numpy_dtype = dtype_mapping[entry.dtype]
-        # print(f"entry.key = {entry.key}")
-        # Normalize compression type (proto3 default is "")
         compression_type = entry.compression_type or None
 
-        # print(f"Compression = {compression_type}, type = {type(compression_type)}")
-
-        # print(f"TopKCompression.__class__.__name__ = {TopKCompression.__name__}")
-        # ----------------------------
-        # CASE 1: Top-K compressed
-        # ----------------------------
         if compression_type == TopKCompression.__name__:
-            # print(f"Data is compressed. Decompressing the data")
-            # Sanity checks
             if not entry.index:
                 raise ValueError(
                     f"Missing indices for compressed tensor {entry.key}"
                 )
 
             index_dtype = dtype_mapping[entry.index_dtype]
-            # Decode values
             values = np.frombuffer(entry.data, dtype=numpy_dtype)
-
-            # Decode indices
             indices = np.frombuffer(entry.index, dtype=index_dtype)
-            # indices = indices.reshape(entry.idx_shape)
             numel = int(np.prod(entry.original_shape))
-            dense = np.zeros(numel, dtype=numpy_dtype)
-
-            # print("proto_to_tensordict => indices.shape:", indices.shape)
-            # print("proto_to_tensordict =>  values.shape:", values.shape)
-            # print("proto_to_tensordict =>  indices:", indices)
-            # print("proto_to_tensordict =>  values:", values)
 
             if len(indices) != len(values):
-                # print(f"Error: protodict_to_tensordict => {entry.dtype}")
                 raise RuntimeError(
                     f"Mismatch: indices ({len(indices)}) != values ({len(values)})"
                 )
 
+            if indices.size == 0:
+                raise RuntimeError(
+                    "proto_to_tensordict -> Index array is empty for TopKCompression"
+                )
 
-
-            if(indices.size == 0):
-                raise RuntimeError("proto_to_tensordict -> Index array is empty for TopKCompression")
-            try:
-                # Reconstruct dense tensor
-                # Get server tensor
-                server_tensor = server_model[entry.key]
-
-
-                # print(f"entry.key = {entry.key} is contained in the server_model")
-
-                # Move to CPU if needed and flatten
-                flat = server_tensor.detach().cpu().numpy().reshape(-1).copy()
-
-                # Overwrite only transmitted indices
+            if overlay_lookup is not None and entry.key in overlay_lookup:
+                base = overlay_lookup[entry.key]
+                flat = base.detach().cpu().numpy().reshape(-1).copy()
                 flat[indices] = values
-
-                # Reshape back
                 dense = flat.reshape(entry.original_shape)
                 is_model_communicated = True
-                # print(f"Compressed data communicated is the model itself")
-            except Exception as e:
-                # print(f"Inside extended the error is {e}")
+            else:
+                dense = np.zeros(numel, dtype=numpy_dtype)
                 dense[indices] = values
 
-            # print(f"TopKCompression; dense.shape = {dense.shape}, entry.shape = {entry.shape}")
             numpy_array = dense.reshape(tuple(entry.original_shape))
 
-        # ----------------------------
-        # CASE 2: Uncompressed (dense)
-        # ----------------------------
+        elif compression_type == QSGDQuantCompression.__name__:
+            if not entry.meta_tensor:
+                raise ValueError(
+                    f"Missing meta_tensor (norm) for QSGD tensor {entry.key}"
+                )
+            if entry.width not in _QSGD_NUMPY_DTYPES:
+                raise ValueError(
+                    f"QSGD tensor {entry.key} has unsupported width={entry.width}"
+                )
+            if entry.level <= 0:
+                raise ValueError(
+                    f"QSGD tensor {entry.key} has invalid level={entry.level}"
+                )
+            qsgd_dtype = _QSGD_NUMPY_DTYPES[entry.width]
+            signed_levels = np.frombuffer(entry.data, dtype=qsgd_dtype).reshape(
+                tuple(entry.original_shape)
+            )
+            norm = float(np.frombuffer(entry.meta_tensor, dtype=np.float32)[0])
+            restored = QSGDQuantCompression.decompress_quantized(
+                torch.from_numpy(signed_levels.copy()),
+                norm,
+                int(entry.level),
+                tuple(entry.original_shape),
+            )
+            numpy_array = restored.detach().cpu().numpy()
+
         elif compression_type is None:
-            # Validate data size (dense case only)
             if len(entry.data) != entry.data_size:
                 raise ValueError(
                     f"Data size mismatch for tensor {entry.key}: "
@@ -384,7 +421,6 @@ def proto_to_tensordict_extended(
                 )
 
             numpy_array = np.frombuffer(entry.data, dtype=numpy_dtype)
-            # print(f"No compression; numpy_array.shape = {numpy_array.shape}, entry.shape = {entry.shape}")
             numpy_array = numpy_array.reshape(tuple(entry.shape))
 
         else:
@@ -392,10 +428,6 @@ def proto_to_tensordict_extended(
                 f"Unsupported compression type: {compression_type}, the type is {type(compression_type)}"
             )
 
-        # ----------------------------
-        # Convert to torch.Tensor
-        # ----------------------------
-        # .copy() because frombuffer gives a read-only view
         tensor = torch.from_numpy(numpy_array.copy()).to(entry.device)
         tensordict[entry.key] = tensor
 

--- a/src/omnifed/engine.py
+++ b/src/omnifed/engine.py
@@ -46,7 +46,7 @@ from .utils import (
 from dataclasses import asdict, is_dataclass
 from omegaconf import OmegaConf
 
-from .slurm_launcher import SlurmConfig, SlurmOnlyLauncher
+from .slurm_launcher import SlurmConfig, SlurmOnlyLauncher, resolve_slurm_frozen_cfg_path
 from .engine_communication import communication_mode, resolve_slurm_ntasks
 import sys
 
@@ -278,9 +278,8 @@ class Engine(RequiredSetup):
 
         if mode == "slurm":
             if "SLURM_JOB_ID" not in os.environ:
-                # 1) Freeze run description once (write to SHARED path)
-                outputs_root = os.path.dirname(os.path.dirname(self.output_dir))
-                cfg_json_shared = os.path.abspath(os.path.join(outputs_root, "engine_frozen.json"))
+                # 1) Freeze run description once (per Hydra run dir — safe for overlapping jobs)
+                cfg_json_path = resolve_slurm_frozen_cfg_path(self.output_dir)
                 from src.omnifed.checkpoint.hybrid_round_checkpoint import (
                     resolve_experiment_checkpoint_dir,
                 )
@@ -294,8 +293,7 @@ class Engine(RequiredSetup):
                     "hydra_output_dir": self.hydra_cfg.runtime.output_dir,
                     "slurm_checkpoint_dir": ckpt_dir,
                 }
-                os.makedirs(outputs_root, exist_ok=True)
-                with open(cfg_json_shared, "w") as f:
+                with open(cfg_json_path, "w") as f:
                     json.dump(frozen, f, indent=2)
 
                 # 2) Build Slurm config dataclass
@@ -305,7 +303,7 @@ class Engine(RequiredSetup):
                 # 3) Runtime fields
                 repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
                 sconf.work_dir = repo_root
-                sconf.cfg_json_path = cfg_json_shared
+                sconf.cfg_json_path = cfg_json_path
                 topo_nodes = len(list(self.topology))
                 sconf.ntasks = resolve_slurm_ntasks(self.cfg, topo_nodes)
                 if comm == "hybrid":

--- a/src/omnifed/hybrid/hybrid_grad_training.py
+++ b/src/omnifed/hybrid/hybrid_grad_training.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, Iterable, Tuple
 import torch
 from torch import nn
 
+from src.omnifed.algorithm import utils
+
 if TYPE_CHECKING:
     from torch.optim import Optimizer
 
@@ -42,6 +44,72 @@ def grad_l2_norm(model: nn.Module) -> float:
     return float(torch.linalg.vector_norm(torch.stack(stacked)).item())
 
 
+def normalize_accumulated_grads(model: nn.Module, num_batches: int) -> None:
+    """Path A: scale summed batch grads to the mean batch grad (FedSGD before sync)."""
+    if num_batches < 1:
+        raise ValueError(
+            f"normalize_accumulated_grads requires num_batches >= 1, got {num_batches}"
+        )
+    utils.scale_grads(model, 1.0 / num_batches)
+
+
+def scale_accumulated_grads_by_batch_size(model: nn.Module, batch_size: int) -> None:
+    """Path B: after backward on a fresh microbatch grad, scale mean → sum (g_b <- g_b * n_b)."""
+    if batch_size < 1:
+        raise ValueError(
+            f"scale_accumulated_grads_by_batch_size requires batch_size >= 1, got {batch_size}"
+        )
+    utils.scale_grads(model, float(batch_size))
+
+
+def init_weighted_grad_accum() -> dict[str, torch.Tensor]:
+    return {}
+
+
+def add_weighted_batch_grad_to_accum(
+    model: nn.Module,
+    batch_size: int,
+    accum: dict[str, torch.Tensor],
+) -> dict[str, torch.Tensor]:
+    """Add ``grad × batch_size`` for the current microbatch into ``accum``."""
+    scale_accumulated_grads_by_batch_size(model, batch_size)
+    for name, param in model.named_parameters():
+        if param.grad is None:
+            continue
+        chunk = param.grad.detach()
+        if name in accum:
+            accum[name] = accum[name] + chunk
+        else:
+            accum[name] = chunk.clone()
+    return accum
+
+
+def load_weighted_grad_accum_into_model(
+    model: nn.Module, accum: dict[str, torch.Tensor]
+) -> None:
+    for name, param in model.named_parameters():
+        if not param.requires_grad:
+            continue
+        if name in accum:
+            param.grad = accum[name].clone()
+        else:
+            param.grad = None
+
+
+def clear_weighted_grad_accum(accum: dict[str, torch.Tensor]) -> None:
+    accum.clear()
+
+
+def normalize_accumulated_grads_by_samples(model: nn.Module, num_samples: int) -> None:
+    """Path B: after local MPI SUM of weighted grad sums, convert G_fac to mean (÷ S_fac)."""
+    if num_samples < 1:
+        raise ValueError(
+            f"normalize_accumulated_grads_by_samples requires num_samples >= 1, "
+            f"got {num_samples}"
+        )
+    utils.scale_grads(model, 1.0 / num_samples)
+
+
 def apply_optimizer_grads(model: nn.Module, optimizer: Optimizer) -> None:
     """Apply sample-weighted averaged gradients already stored in ``param.grad``."""
     require_model_grads(model)
@@ -58,9 +126,16 @@ def clear_model_grads(model: nn.Module, *, optimizer: Optimizer | None = None) -
 
 
 __all__ = [
+    "add_weighted_batch_grad_to_accum",
     "apply_optimizer_grads",
     "clear_model_grads",
+    "clear_weighted_grad_accum",
     "grad_l2_norm",
+    "init_weighted_grad_accum",
+    "load_weighted_grad_accum_into_model",
     "missing_grad_param_names",
+    "normalize_accumulated_grads",
+    "normalize_accumulated_grads_by_samples",
     "require_model_grads",
+    "scale_accumulated_grads_by_batch_size",
 ]

--- a/src/omnifed/slurm_launcher.py
+++ b/src/omnifed/slurm_launcher.py
@@ -12,6 +12,11 @@ def _inside_slurm() -> bool:
     return "SLURM_JOB_ID" in os.environ
 
 
+def resolve_slurm_frozen_cfg_path(hydra_output_dir: str) -> str:
+    """Absolute path to per-run ``engine_frozen.json`` (under the Hydra run directory)."""
+    return os.path.abspath(os.path.join(hydra_output_dir, "engine_frozen.json"))
+
+
 @dataclass
 class SlurmConfig:
     enabled: bool = False

--- a/src/omnifed/slurm_worker.py
+++ b/src/omnifed/slurm_worker.py
@@ -13,6 +13,10 @@ import torch
 import torch.distributed as dist
 
 from src.omnifed.engine_communication import communication_mode
+from src.omnifed.classic.classic_grad_config import (
+    classic_aggregate_payload_from_cfg,
+    format_classic_grad_policy,
+)
 from src.omnifed.communicator import AggregationOp
 from src.omnifed.utils import print  # pretty printer used elsewhere
 
@@ -25,6 +29,61 @@ def _first_host_from_nodelist() -> str:
         text=True,
     )
     return out.strip().splitlines()[0]
+
+
+def _grpc_server_ready_marker(hydra_out_dir: str) -> str:
+    """Shared Lustre marker: rank 0 creates it after gRPC listen; clients poll before connect."""
+    return os.path.join(hydra_out_dir, "engine", ".grpc_server_ready")
+
+
+def _write_grpc_server_ready_marker(
+    hydra_out_dir: str, *, master_addr: str, master_port: str
+) -> str:
+    path = _grpc_server_ready_marker(hydra_out_dir)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(f"{master_addr}:{master_port}\n")
+    return path
+
+
+def _wait_for_grpc_server_ready_marker(
+    hydra_out_dir: str,
+    *,
+    rank: int,
+    timeout_s: Optional[float] = None,
+    poll_s: float = 1.0,
+) -> None:
+    """Block until rank 0 writes ``engine/.grpc_server_ready`` (multi-node Slurm startup)."""
+    if timeout_s is None:
+        timeout_s = float(os.environ.get("OMNIFED_GRPC_READY_TIMEOUT_SEC", "900"))
+    poll_s = float(os.environ.get("OMNIFED_GRPC_READY_POLL_SEC", str(poll_s)))
+    path = _grpc_server_ready_marker(hydra_out_dir)
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if os.path.isfile(path):
+            print(
+                f"[slurm_worker] rank={rank}: gRPC server ready marker found ({path})",
+                flush=True,
+            )
+            return
+        time.sleep(poll_s)
+    raise RuntimeError(
+        f"[slurm_worker] rank={rank}: timed out after {timeout_s:.0f}s waiting for "
+        f"gRPC server ready marker {path}. Rank 0 may not have started listening."
+    )
+
+
+def _uses_grpc_centralized_server(local_comm) -> bool:
+    return hasattr(local_comm, "is_server") and hasattr(local_comm, "master_port")
+
+
+def _classic_comm_backend_name(local_comm) -> str:
+    name = type(local_comm).__name__.lower()
+    if "grpc" in name:
+        return "grpc"
+    if "torchdist" in name:
+        return "torchdist"
+    return name
 
 
 def install_preemption_handlers(on_checkpoint):
@@ -43,6 +102,32 @@ def _safe_len_train(dm) -> int:
         return len(dm.train) if dm.train is not None else 0
     except Exception:
         return 0
+
+
+def _resolve_slurm_device(
+    node_cfg,
+    *,
+    rank: int,
+    local_rank: int,
+    local_comm,
+) -> torch.device:
+    """Pick compute device for this Slurm task (classic centralized path).
+
+    Honors ``topology.overrides.<rank>.device_hint`` when set (e.g. ``cpu`` for
+    rank-0 gRPC server). Otherwise trainers and rank-0 server use GPU when the
+    communicator reports an NCCL backend and CUDA is available.
+    """
+    device_hint = getattr(node_cfg, "device_hint", "auto")
+
+    if device_hint != "auto":
+        print(f"[slurm_worker] Explicit device_hint={device_hint}", flush=True)
+        return torch.device(device_hint)
+
+    backend = getattr(local_comm, "backend", "gloo").lower()
+    use_cuda = (backend == "nccl") and torch.cuda.is_available()
+    if use_cuda:
+        return _resolve_device_auto(local_rank)
+    return torch.device("cpu")
 
 
 def _resolve_device_auto(rank: Optional[int]) -> torch.device:
@@ -127,14 +212,11 @@ def _to_jsonable(obj):
 
 def start_gpu_memory_logger(rank: int, log_dir: str, interval_sec: float = 5.0):
     """
-    Periodically log GPU memory usage for rank 0 only.
+    Periodically log GPU memory usage for every rank.
     Works on ROCm through torch.cuda APIs.
     """
-    if rank != 0:
-        return None
-
     os.makedirs(log_dir, exist_ok=True)
-    log_path = os.path.join(log_dir, "rank0_gpu_memory.log")
+    log_path = os.path.join(log_dir, f"rank{int(rank)}_gpu_memory.log")
     stop_event = threading.Event()
 
     def _logger():
@@ -174,9 +256,9 @@ def start_gpu_memory_logger(rank: int, log_dir: str, interval_sec: float = 5.0):
 
 def log_gpu_memory_snapshot(rank: int, log_path: str, tag: str):
     """
-    Write one on-demand GPU memory snapshot for rank 0 only.
+    Write one on-demand GPU memory snapshot for this rank.
     """
-    if rank != 0 or not torch.cuda.is_available():
+    if not torch.cuda.is_available():
         return
 
     try:
@@ -236,21 +318,26 @@ def main():
 
     # Patch communicator config so it does not keep localhost/127.0.0.1
     if hasattr(cfg.topology, "local_comm") and cfg.topology.local_comm is not None:
-        if "master_addr" in cfg.topology.local_comm:
-            cfg.topology.local_comm["master_addr"] = master_addr
+        OmegaConf.set_struct(cfg.topology.local_comm, False)
         if "master_port" in cfg.topology.local_comm:
+            cfg.topology.local_comm["master_addr"] = master_addr
             cfg.topology.local_comm["master_port"] = master_port
+        elif "master_addr" in cfg.topology.local_comm:
+            cfg.topology.local_comm["master_addr"] = master_addr
 
     if hasattr(cfg.topology, "global_comm") and cfg.topology.global_comm is not None:
-        if "master_addr" in cfg.topology.global_comm:
-            cfg.topology.global_comm["master_addr"] = master_addr
+        OmegaConf.set_struct(cfg.topology.global_comm, False)
         if "master_port" in cfg.topology.global_comm:
+            cfg.topology.global_comm["master_addr"] = master_addr
             cfg.topology.global_comm["master_port"] = master_port
+        elif "master_addr" in cfg.topology.global_comm:
+            cfg.topology.global_comm["master_addr"] = master_addr
 
+    lc = cfg.topology.local_comm
     print(
         f"[main] patched communicator config: "
-        f"local_comm.master_addr={cfg.topology.local_comm.master_addr} "
-        f"local_comm.master_port={cfg.topology.local_comm.master_port}",
+        f"local_comm.master_addr={OmegaConf.select(lc, 'master_addr', default=master_addr)} "
+        f"local_comm.master_port={OmegaConf.select(lc, 'master_port', default=master_port)}",
         flush=True,
     )
 
@@ -279,15 +366,29 @@ def main():
     # ---------- Instantiate communicator/model/datamodule/algorithm ----------
     local_comm  = instantiate(node_cfg.local_comm)  # default _recursive_=True
     global_comm = instantiate(node_cfg.global_comm) if getattr(node_cfg, "global_comm", None) else None
+
+    # Multi-node Slurm: rank 0 listens early; clients wait on a shared Lustre marker
+    # before connecting (task launch order across nodes is nondeterministic).
+    if rank == 0 and _uses_grpc_centralized_server(local_comm) and local_comm.is_server:
+        local_comm.setup()
+        ready_path = _write_grpc_server_ready_marker(
+            hydra_out_dir, master_addr=master_addr, master_port=master_port
+        )
+        print(
+            f"[slurm_worker] rank 0: gRPC server started early (before model load); "
+            f"ready marker -> {ready_path}",
+            flush=True,
+        )
+
     model       = instantiate(cfg.model)
     datamodule  = instantiate(cfg.datamodule)
     algorithm   = instantiate(node_cfg.algorithm, log_dir=node_log_dir)
 
     # ---------- Device selection ----------
-    # If communicator backend is NCCL, we must put tensors on CUDA before collectives.
+    device = _resolve_slurm_device(
+        node_cfg, rank=rank, local_rank=local_rank, local_comm=local_comm
+    )
     backend = getattr(local_comm, "backend", "gloo").lower()
-    use_cuda = (backend == "nccl") and torch.cuda.is_available()
-    device = _resolve_device_auto(local_rank) if use_cuda else torch.device("cpu")
     original_device = next(model.parameters()).device
     model = model.to(device, non_blocking=True)
 
@@ -299,13 +400,22 @@ def main():
 
     if mem_logger is not None:
         mem_stop_event, mem_log_path = mem_logger
-        print(f"[main] rank 0 GPU memory log -> {mem_log_path}", flush=True)
+        print(
+            f"[main] rank {rank} GPU memory log -> {mem_log_path}",
+            flush=True,
+        )
         log_gpu_memory_snapshot(rank, mem_log_path, "after_model_to_device")
     else:
         mem_stop_event = None
         mem_log_path = ""
 
     # ---------- Init process group via communicator ----------
+    if (
+        rank != 0
+        and _uses_grpc_centralized_server(local_comm)
+        and not local_comm.is_server
+    ):
+        _wait_for_grpc_server_ready_marker(hydra_out_dir, rank=rank)
     local_comm.setup()
     if global_comm:
         global_comm.setup()
@@ -362,6 +472,47 @@ def main():
         total_rounds,
     )
 
+    # After algorithm.setup(): logger may call progress_info_str during gRPC metrics.
+    if hasattr(local_comm, "set_logger"):
+        local_comm.set_logger(algorithm)
+    if global_comm and hasattr(global_comm, "set_logger"):
+        global_comm.set_logger(algorithm)
+
+    if classic_aggregate_payload_from_cfg(cfg) == "gradients":
+        from src.omnifed.classic.classic_grad_slurm import install_classic_grad_slurm_sync
+        from src.omnifed.summary.per_iteration import install_iteration_recorder
+
+        print(
+            f"[slurm_worker] classic grad track: {format_classic_grad_policy(cfg)}",
+            flush=True,
+        )
+        install_iteration_recorder(
+            cfg,
+            algorithm,
+            rank=rank,
+            log_dir=os.path.join(hydra_out_dir, "engine"),
+            comm_backend=_classic_comm_backend_name(local_comm),
+            aggregate_payload="gradients",
+        )
+        install_classic_grad_slurm_sync(algorithm, local_comm=local_comm)
+    elif classic_aggregate_payload_from_cfg(cfg) == "params":
+        from src.omnifed.classic.classic_param_slurm import install_classic_param_slurm_sync
+        from src.omnifed.summary.per_iteration import install_iteration_recorder
+
+        print(
+            "[slurm_worker] classic param track: aggregate_payload='params' (batch_end sync)",
+            flush=True,
+        )
+        install_iteration_recorder(
+            cfg,
+            algorithm,
+            rank=rank,
+            log_dir=os.path.join(hydra_out_dir, "engine"),
+            comm_backend=_classic_comm_backend_name(local_comm),
+            aggregate_payload="params",
+        )
+        install_classic_param_slurm_sync(algorithm, local_comm=local_comm)
+
     # Ensure the algorithm's model lives on our chosen device
     # try:
     #     alg_dev = next(algorithm.local_model.parameters()).device
@@ -399,6 +550,7 @@ def main():
 
     # ---------- Persist per-rank results ----------
     results = algorithm.get_experiment_data()
+    algorithm.close_metrics()
     node_results_dir = os.path.join(hydra_out_dir, "engine", "node_results")
     os.makedirs(node_results_dir, exist_ok=True)
     out_path = os.path.join(node_results_dir, f"node_{rank:03d}_results.pkl")
@@ -409,6 +561,18 @@ def main():
     with open(out_path_json, "w", encoding="utf-8") as f:
         json.dump(_to_jsonable(results), f, ensure_ascii=False, indent=2)
     print(f"[slurm_worker] wrote JSON results -> {out_path_json}", flush=True)
+
+    client_ranks = [r for r in range(world) if r != 0]
+    if client_ranks and rank == min(client_ranks):
+        from src.omnifed.summary.slurm_per_round import write_slurm_per_round_summary_for_run
+
+        write_slurm_per_round_summary_for_run(
+            cfg,
+            hydra_out_dir,
+            world_size=world,
+            rpc_server_rank=0,
+            rank_writer=rank,
+        )
 
     print(f"[main]  wrote results -> {out_path}", flush=True)
     print(f"[main]  rank={rank} finished.", flush=True)

--- a/src/omnifed/summary/__init__.py
+++ b/src/omnifed/summary/__init__.py
@@ -1,0 +1,19 @@
+"""Universal Slurm summary generation (classic centralized and hybrid)."""
+
+from src.omnifed.summary.per_iteration import (
+    accumulate_iter_comm,
+    install_iteration_recorder,
+)
+from src.omnifed.summary.pipeline import summary_mode_from_cfg
+from src.omnifed.summary.slurm_per_round import (
+    write_slurm_per_round_summary,
+    write_slurm_per_round_summary_for_run,
+)
+
+__all__ = [
+    "accumulate_iter_comm",
+    "install_iteration_recorder",
+    "summary_mode_from_cfg",
+    "write_slurm_per_round_summary",
+    "write_slurm_per_round_summary_for_run",
+]

--- a/src/omnifed/summary/classic_per_round.py
+++ b/src/omnifed/summary/classic_per_round.py
@@ -1,0 +1,123 @@
+"""Classic centralized per-round summary table builder."""
+
+from __future__ import annotations
+
+import csv
+import io
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from src.omnifed.summary.metrics_full import (
+    eval_loss_avg_for_round,
+    format_ms,
+    sync_metric_max_for_round,
+    sync_metric_mean_for_round,
+    sync_round_indices,
+    train_loss_avg_for_round,
+)
+
+
+def build_classic_per_round_tables(
+    *,
+    payloads: Dict[int, Dict[str, Any]],
+    trainer_ranks: Sequence[int],
+) -> Tuple[str, str]:
+    """Markdown table + CSV body (flat topology, no facility columns)."""
+    all_rounds: set[int] = set()
+    for gr in trainer_ranks:
+        pl = payloads.get(gr) or {}
+        all_rounds.update(sync_round_indices(pl.get("sync") or []))
+    rounds_sorted = sorted(all_rounds)
+
+    hdr_tail = [
+        "grpc_agg_mean_ms",
+        "grpc_agg_max_ms",
+        "grad_apply_max_ms",
+        "eval_loss_avg",
+        "n_eval_trainers",
+        "train_loss_avg",
+    ]
+    tbl_header = "| round_idx | " + " | ".join(hdr_tail) + " |"
+    ncols = 1 + len(hdr_tail)
+    sep_row = "|" + "|".join([":---"] * ncols) + "|"
+    md_rows = [tbl_header, sep_row]
+
+    csv_header = ["round_idx", *hdr_tail]
+    buf = io.StringIO()
+    w = csv.writer(buf)
+    w.writerow(csv_header)
+
+    for ridx in rounds_sorted:
+        agg_mean_vals: List[float] = []
+        agg_max_vals: List[float] = []
+        apply_vals: List[float] = []
+        for gr in trainer_ranks:
+            sync_list = (payloads.get(gr) or {}).get("sync") or []
+            xa_mean = sync_metric_mean_for_round(sync_list, ridx, "local_agg_time")
+            xa_max = sync_metric_max_for_round(sync_list, ridx, "local_agg_time")
+            xg = sync_metric_max_for_round(sync_list, ridx, "grad_apply_time")
+            if xa_mean is not None:
+                agg_mean_vals.append(xa_mean)
+            if xa_max is not None:
+                agg_max_vals.append(xa_max)
+            if xg is not None:
+                apply_vals.append(xg)
+        grpc_mean_ms = max(agg_mean_vals) if agg_mean_vals else None
+        grpc_max_ms = max(agg_max_vals) if agg_max_vals else None
+        grad_apply_ms = max(apply_vals) if apply_vals else None
+
+        loss_list: List[float] = []
+        for gr in trainer_ranks:
+            lo = eval_loss_avg_for_round((payloads.get(gr) or {}).get("eval") or [], ridx)
+            if lo is not None:
+                loss_list.append(lo)
+        loss_txt = f"{sum(loss_list) / len(loss_list):.6f}" if loss_list else "—"
+
+        train_loss_list: List[float] = []
+        for gr in trainer_ranks:
+            tl = train_loss_avg_for_round((payloads.get(gr) or {}).get("train") or [], ridx)
+            if tl is not None:
+                train_loss_list.append(tl)
+        train_loss_txt = (
+            f"{sum(train_loss_list) / len(train_loss_list):.6f}"
+            if train_loss_list
+            else "—"
+        )
+
+        md_cells = [
+            format_ms(grpc_mean_ms),
+            format_ms(grpc_max_ms),
+            format_ms(grad_apply_ms),
+            loss_txt,
+            str(len(loss_list)),
+            train_loss_txt,
+        ]
+        md_rows.append("| " + str(ridx) + " | " + " | ".join(md_cells) + " |")
+
+        w.writerow(
+            [
+                ridx,
+                format_ms(grpc_mean_ms),
+                format_ms(grpc_max_ms),
+                format_ms(grad_apply_ms),
+                loss_txt,
+                str(len(loss_list)),
+                train_loss_txt,
+            ]
+        )
+
+    intro = "\n".join(
+        [
+            "",
+            "### Classic centralized per-global-round summary (from Node0 metrics_full + node_results)",
+            "",
+            "**Data source:** ``Node0.*/metrics_full.csv`` (primary); ``node_*_results.json`` (secondary). ",
+            "**grpc_agg_mean_ms:** **max** across clients of per-trainer **mean** `sync/local_agg_time` for that round (**ms**). ",
+            "Same timing buckets apply to gRPC and TorchDist (column name is historical). ",
+            "**grpc_agg_max_ms:** **max** `sync/local_agg_time` across all client batch syncs in that round (**ms**). ",
+            "**grad_apply_max_ms:** **max** `sync/grad_apply_time` across client trainers (**ms**). ",
+            "**eval_loss_avg:** mean across trainers of eval loss at **round end** (`eval/loss`). ",
+            "**train_loss_avg:** mean across trainers of batch training loss for that round (`train/loss`). ",
+            "",
+        ]
+    )
+    return intro + "\n".join(md_rows) + "\n", buf.getvalue()

--- a/src/omnifed/summary/hybrid_per_round.py
+++ b/src/omnifed/summary/hybrid_per_round.py
@@ -1,0 +1,132 @@
+"""Hybrid per-round summary table builder."""
+
+from __future__ import annotations
+
+import csv
+import io
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from src.omnifed.summary.metrics_full import (
+    eval_accuracy_avg_for_round,
+    eval_loss_avg_for_round,
+    format_ms,
+    sync_metric_max_for_round,
+    sync_round_indices,
+)
+
+
+def _fac_leader_ranks(topo: Any) -> List[int]:
+    leaders: List[int] = []
+    for fac in topo.facilities:
+        members = [int(m) for m in fac.mpi.members]
+        if not members:
+            raise ValueError("facility with empty members in topology")
+        leaders.append(members[0])
+    return leaders
+
+
+def _fac_member_ranks(topo: Any) -> List[List[int]]:
+    return [[int(m) for m in fac.mpi.members] for fac in topo.facilities]
+
+
+def build_hybrid_per_round_tables(
+    *,
+    topo: Any,
+    payloads: Dict[int, Dict[str, Any]],
+    trainer_ranks: Sequence[int],
+) -> Tuple[str, str]:
+    """Markdown (table only) + CSV body as strings."""
+    leaders = _fac_leader_ranks(topo)
+    members_by_f = _fac_member_ranks(topo)
+    n_f = len(leaders)
+
+    all_rounds: set[int] = set()
+    for gr in trainer_ranks:
+        pl = payloads.get(gr) or {}
+        all_rounds.update(sync_round_indices(pl.get("sync") or []))
+    rounds_sorted = sorted(all_rounds)
+
+    hdr_g = [f"gRPC_F{i+1}_ms" for i in range(n_f)]
+    hdr_la = [f"local_agg_F{i+1}_max_ms" for i in range(n_f)]
+    hdr_lb = [f"local_bcast_F{i+1}_max_ms" for i in range(n_f)]
+    hdr_tail = ["accuracy_avg", "n_acc_trainers", "eval_loss_avg", "n_eval_trainers"]
+
+    tbl_header = "| round_idx | " + " | ".join([*hdr_g, *hdr_la, *hdr_lb, *hdr_tail]) + " |"
+    ncols = 1 + len(hdr_g) + len(hdr_la) + len(hdr_lb) + len(hdr_tail)
+    sep_row = "|" + "|".join([":---"] * ncols) + "|"
+
+    md_rows = [tbl_header, sep_row]
+
+    csv_header = ["round_idx", *hdr_g, *hdr_la, *hdr_lb, *hdr_tail]
+    buf = io.StringIO()
+    w = csv.writer(buf)
+    w.writerow(csv_header)
+
+    for ridx in rounds_sorted:
+        grpc = []
+        for lr in leaders:
+            sync_list = (payloads.get(lr) or {}).get("sync") or []
+            grpc.append(sync_metric_max_for_round(sync_list, ridx, "global_agg_time"))
+
+        la_m: List[Optional[float]] = []
+        lb_m: List[Optional[float]] = []
+        for members in members_by_f:
+            la_v: List[float] = []
+            lb_v: List[float] = []
+            for gr in members:
+                sync_list = (payloads.get(gr) or {}).get("sync") or []
+                xa = sync_metric_max_for_round(sync_list, ridx, "local_agg_time")
+                xb = sync_metric_max_for_round(sync_list, ridx, "local_bcast_time")
+                if xa is not None:
+                    la_v.append(xa)
+                if xb is not None:
+                    lb_v.append(xb)
+            la_m.append(max(la_v) if la_v else None)
+            lb_m.append(max(lb_v) if lb_v else None)
+
+        acc_list: List[float] = []
+        for gr in trainer_ranks:
+            a = eval_accuracy_avg_for_round((payloads.get(gr) or {}).get("eval") or [], ridx)
+            if a is not None:
+                acc_list.append(a)
+        acc_txt = f"{sum(acc_list) / len(acc_list):.4f}" if acc_list else "—"
+
+        loss_list: List[float] = []
+        for gr in trainer_ranks:
+            lo = eval_loss_avg_for_round((payloads.get(gr) or {}).get("eval") or [], ridx)
+            if lo is not None:
+                loss_list.append(lo)
+        loss_txt = f"{sum(loss_list) / len(loss_list):.6f}" if loss_list else "—"
+
+        md_cells = (
+            [* [format_ms(x) for x in grpc], * [format_ms(x) for x in la_m], * [format_ms(x) for x in lb_m],
+             acc_txt, str(len(acc_list)), loss_txt, str(len(loss_list))]
+        )
+        md_rows.append("| " + str(ridx) + " | " + " | ".join(md_cells) + " |")
+
+        csv_row = [ridx]
+        csv_row.extend(format_ms(x) for x in grpc)
+        csv_row.extend(format_ms(x) for x in la_m)
+        csv_row.extend(format_ms(x) for x in lb_m)
+        csv_row.extend([acc_txt, str(len(acc_list)), loss_txt, str(len(loss_list))])
+        w.writerow(csv_row)
+
+    intro = "\n".join(
+        [
+            "",
+            "### Hybrid per-global-round summary (from Node0 metrics_full + node_results)",
+            "",
+            "**Data source:** ``Node0.*/metrics_full.csv`` (primary); ``node_*_results.json`` (secondary). ",
+            "**gRPC_*:** **max** `sync/global_agg_time` on facility leader across all ``sync`` ",
+            "rows in that outer round (**ms**). ",
+            "**local_agg_* / local_bcast_*:** **max** over ranks in facility, each rank taking ",
+            "the **max** across local/global sync events in that outer round (**ms**). ",
+            "**accuracy_avg:** mean of per-trainer *accuracy* scalars logged in **`eval`** for that round ",
+            "(keys containing `accuracy`, case‑insensitive). Requires eval to record accuracy.",
+            "**eval_loss_avg:** mean across trainers of per-trainer average **`eval/loss`** (multiple eval ",
+            "rows sharing the same **round_idx** are averaged inside each trainer first).",
+            "",
+        ]
+    )
+    md = intro + "\n".join(md_rows) + "\n"
+    return md, buf.getvalue()

--- a/src/omnifed/summary/metrics_full.py
+++ b/src/omnifed/summary/metrics_full.py
@@ -1,0 +1,444 @@
+"""Shared metrics_full.csv loading and per-round aggregation helpers."""
+
+from __future__ import annotations
+
+import csv
+import glob
+import io
+import json
+import math
+import os
+from typing import Any, Dict, List, Optional, Sequence
+
+from src.omnifed.hybrid.topology_roles import hybrid_rank_to_centralized_node_index
+
+_METRICS_FULL_META_COLS = ("global_step", "round_idx", "epoch_idx", "batch_idx")
+
+
+def load_node_json(path: str) -> Optional[Dict[str, Any]]:
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
+def load_context_records_from_metrics_full_csv(
+    csv_path: str, *, agg_context: str
+) -> List[Dict[str, Any]]:
+    """Rebuild wide context rows from long-format ``metrics_full.csv`` (always complete)."""
+    groups: Dict[tuple, Dict[str, Any]] = {}
+    try:
+        with open(csv_path, newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                if row.get("agg_ctx") != agg_context:
+                    continue
+                meta: Dict[str, Any] = {}
+                key_parts: List[tuple[str, str]] = []
+                for col in _METRICS_FULL_META_COLS:
+                    val = row.get(col)
+                    if val is None or val == "":
+                        continue
+                    meta[col] = val
+                    key_parts.append((col, str(val)))
+                gkey = tuple(key_parts)
+                if gkey not in groups:
+                    groups[gkey] = dict(meta)
+                metric_key = row.get("metric_key") or ""
+                if not metric_key:
+                    continue
+                raw_val = row.get("metric_val")
+                try:
+                    groups[gkey][metric_key] = float(raw_val)
+                except (TypeError, ValueError):
+                    groups[gkey][metric_key] = raw_val
+    except OSError:
+        return []
+
+    def _sort_key(rec: Dict[str, Any]) -> int:
+        try:
+            return int(float(rec.get("global_step", 0)))
+        except (TypeError, ValueError):
+            return 0
+
+    return sorted(groups.values(), key=_sort_key)
+
+
+def payloads_from_metrics_full_for_trainers(
+    hydra_out_dir: str,
+    *,
+    trainer_ranks: Sequence[int],
+    rpc_server_rank: int,
+    world_size: int,
+    contexts: Sequence[str] = ("sync", "eval"),
+) -> Dict[int, Dict[str, Any]]:
+    """Build per-rank payload dicts directly from ``Node0.*/metrics_full.csv``."""
+    num_clients = len(trainer_ranks)
+    payloads: Dict[int, Dict[str, Any]] = {}
+    for gr in trainer_ranks:
+        try:
+            node_idx = hybrid_rank_to_centralized_node_index(
+                int(gr),
+                rpc_server_rank=int(rpc_server_rank),
+                world_size=int(world_size),
+                num_clients=int(num_clients),
+            )
+        except ValueError:
+            continue
+        full_path = os.path.join(hydra_out_dir, f"Node0.{node_idx}", "metrics_full.csv")
+        if not os.path.isfile(full_path):
+            continue
+        pl: Dict[str, Any] = {"rank": int(gr)}
+        for ctx in contexts:
+            records = load_context_records_from_metrics_full_csv(full_path, agg_context=ctx)
+            if records:
+                pl[ctx] = records
+        if len(pl) > 1:
+            payloads[int(gr)] = pl
+    return payloads
+
+
+def merge_json_payloads_into(
+    payloads: Dict[int, Dict[str, Any]],
+    hydra_out_dir: str,
+) -> None:
+    """Attach JSON-only fields; never overwrite sync/eval already loaded from metrics_full."""
+    rd = os.path.join(hydra_out_dir, "engine", "node_results")
+    for p in sorted(glob.glob(os.path.join(rd, "node_*_results.json"))):
+        try:
+            gr = int(os.path.basename(p).replace("node_", "").replace("_results.json", ""))
+        except ValueError:
+            continue
+        pl = load_node_json(p)
+        if not isinstance(pl, dict) or pl.get("role") == "hybrid_grpc_server":
+            continue
+        existing = payloads.get(gr)
+        if existing is None:
+            payloads[gr] = pl
+            continue
+        for key, val in pl.items():
+            if key in ("sync", "eval"):
+                if key not in existing or not existing.get(key):
+                    existing[key] = val
+                continue
+            existing[key] = val
+
+
+def trainers_metrics_full_ready(
+    hydra_out_dir: str,
+    *,
+    trainer_ranks: Sequence[int],
+    rpc_server_rank: int,
+    world_size: int,
+) -> int:
+    """Count trainers with a ``metrics_full.csv`` on disk."""
+    num_clients = len(trainer_ranks)
+    ready = 0
+    for gr in trainer_ranks:
+        try:
+            node_idx = hybrid_rank_to_centralized_node_index(
+                int(gr),
+                rpc_server_rank=int(rpc_server_rank),
+                world_size=int(world_size),
+                num_clients=int(num_clients),
+            )
+        except ValueError:
+            continue
+        if os.path.isfile(os.path.join(hydra_out_dir, f"Node0.{node_idx}", "metrics_full.csv")):
+            ready += 1
+    return ready
+
+
+def load_sync_records_from_metrics_full_csv(csv_path: str) -> List[Dict[str, Any]]:
+    return load_context_records_from_metrics_full_csv(csv_path, agg_context="sync")
+
+
+def enrich_payloads_from_metrics_full(
+    hydra_out_dir: str,
+    payloads: Dict[int, Dict[str, Any]],
+    *,
+    trainer_ranks: Sequence[int],
+    rpc_server_rank: int,
+    world_size: int,
+    contexts: Sequence[str] = ("sync", "eval"),
+) -> None:
+    """Prefer on-disk ``Node0.*/metrics_full.csv`` for metric contexts."""
+    num_clients = len(trainer_ranks)
+    for gr, pl in payloads.items():
+        try:
+            node_idx = hybrid_rank_to_centralized_node_index(
+                int(gr),
+                rpc_server_rank=int(rpc_server_rank),
+                world_size=int(world_size),
+                num_clients=int(num_clients),
+            )
+        except ValueError:
+            continue
+        full_path = os.path.join(hydra_out_dir, f"Node0.{node_idx}", "metrics_full.csv")
+        if not os.path.isfile(full_path):
+            continue
+        for ctx in contexts:
+            records = load_context_records_from_metrics_full_csv(full_path, agg_context=ctx)
+            if records:
+                pl[ctx] = records
+
+
+def enrich_payloads_sync_from_metrics_full(
+    hydra_out_dir: str,
+    payloads: Dict[int, Dict[str, Any]],
+    *,
+    trainer_ranks: Sequence[int],
+    rpc_server_rank: int,
+    world_size: int,
+) -> None:
+    enrich_payloads_from_metrics_full(
+        hydra_out_dir,
+        payloads,
+        trainer_ranks=trainer_ranks,
+        rpc_server_rank=rpc_server_rank,
+        world_size=world_size,
+        contexts=("sync",),
+    )
+
+
+def enrich_payloads_eval_from_metrics_full(
+    hydra_out_dir: str,
+    payloads: Dict[int, Dict[str, Any]],
+    *,
+    trainer_ranks: Sequence[int],
+    rpc_server_rank: int,
+    world_size: int,
+) -> None:
+    enrich_payloads_from_metrics_full(
+        hydra_out_dir,
+        payloads,
+        trainer_ranks=trainer_ranks,
+        rpc_server_rank=rpc_server_rank,
+        world_size=world_size,
+        contexts=("eval",),
+    )
+
+
+def metrics_full_has_eval_loss(hydra_out_dir: str, node_idx: int) -> bool:
+    full_path = os.path.join(hydra_out_dir, f"Node0.{node_idx}", "metrics_full.csv")
+    if not os.path.isfile(full_path):
+        return False
+    try:
+        with open(full_path, newline="", encoding="utf-8") as f:
+            for row in csv.DictReader(f):
+                if row.get("agg_ctx") == "eval" and row.get("metric_key") == "eval/loss":
+                    return True
+    except OSError:
+        return False
+    return False
+
+
+def summary_csv_has_eval_trainers(csv_txt: str) -> bool:
+    buf = io.StringIO(csv_txt)
+    reader = csv.DictReader(buf)
+    for row in reader:
+        try:
+            if int(str(row.get("n_eval_trainers", "0")).strip()) > 0:
+                return True
+        except ValueError:
+            continue
+    return False
+
+
+def warn_if_summary_missing_eval(
+    *,
+    mode: str,
+    hydra_out_dir: str,
+    trainer_ranks: Sequence[int],
+    rpc_server_rank: int,
+    world_size: int,
+    csv_txt: str,
+) -> None:
+    """Emit a loud warning when eval ran on disk but the summary table has no loss."""
+    if summary_csv_has_eval_trainers(csv_txt):
+        return
+
+    num_clients = len(trainer_ranks)
+    on_disk = 0
+    for gr in trainer_ranks:
+        try:
+            node_idx = hybrid_rank_to_centralized_node_index(
+                int(gr),
+                rpc_server_rank=int(rpc_server_rank),
+                world_size=int(world_size),
+                num_clients=int(num_clients),
+            )
+        except ValueError:
+            continue
+        if metrics_full_has_eval_loss(hydra_out_dir, node_idx):
+            on_disk += 1
+
+    if on_disk == 0:
+        return
+
+    print(
+        f"[{mode}] summary WARN: eval_loss_avg is empty but "
+        f"metrics_full.csv on {on_disk}/{len(trainer_ranks)} trainers contains eval/loss. "
+        "Update summary metrics_full enrich and regenerate, or rsync latest OmniFed_VT.",
+        flush=True,
+    )
+
+
+def get_f(row: Dict[str, Any], key: str) -> Optional[float]:
+    if key not in row or row[key] is None or row[key] == "":
+        return None
+    try:
+        return float(row[key])
+    except (TypeError, ValueError):
+        return None
+
+
+def row_round_idx(row: Dict[str, Any]) -> Optional[int]:
+    """Parse ``round_idx`` from a metric row; skip missing / NaN (malformed CSV rows)."""
+    raw = row.get("round_idx")
+    if raw is None or raw == "":
+        return None
+    if isinstance(raw, float) and math.isnan(raw):
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def sync_metric_seconds(row: Optional[Dict[str, Any]], base: str) -> Optional[float]:
+    """Resolve ``sync/*`` timings as stored by MetricLogger (``sync/global_agg_time`` …)."""
+    if not row:
+        return None
+    v = get_f(row, base)
+    if v is not None:
+        return v
+    return get_f(row, f"sync/{base}")
+
+
+def sync_round_indices(sync_list: List[Dict[str, Any]]) -> set[int]:
+    """All outer ``round_idx`` values present in a trainer's ``sync`` list."""
+    out: set[int] = set()
+    for row in sync_list or []:
+        if not isinstance(row, dict):
+            continue
+        ridx = row_round_idx(row)
+        if ridx is not None:
+            out.add(ridx)
+    return out
+
+
+def sync_rows_for_round(sync_list: List[Dict[str, Any]], round_idx: int) -> List[Dict[str, Any]]:
+    """Every flushed ``sync`` row for one outer round (custom freq ⇒ multiple rows)."""
+    rows: List[Dict[str, Any]] = []
+    for row in sync_list or []:
+        if not isinstance(row, dict):
+            continue
+        if row_round_idx(row) == round_idx:
+            rows.append(row)
+    return rows
+
+
+def sync_metric_max_for_round(
+    sync_list: List[Dict[str, Any]], round_idx: int, base: str
+) -> Optional[float]:
+    vals: List[float] = []
+    for row in sync_rows_for_round(sync_list, round_idx):
+        v = sync_metric_seconds(row, base)
+        if v is not None:
+            vals.append(v)
+    if not vals:
+        return None
+    return max(vals)
+
+
+def sync_metric_mean_for_round(
+    sync_list: List[Dict[str, Any]], round_idx: int, base: str
+) -> Optional[float]:
+    """Mean timing across all ``sync`` rows for ``round_idx`` (batch-level sync)."""
+    vals: List[float] = []
+    for row in sync_rows_for_round(sync_list, round_idx):
+        v = sync_metric_seconds(row, base)
+        if v is not None:
+            vals.append(v)
+    if not vals:
+        return None
+    return sum(vals) / len(vals)
+
+
+def train_loss_avg_for_round(
+    train_list: List[Dict[str, Any]], round_idx: int
+) -> Optional[float]:
+    """Mean batch training loss for ``round_idx`` (``train/loss`` from MetricLogger)."""
+    vals: List[float] = []
+    for row in train_list or []:
+        if not isinstance(row, dict):
+            continue
+        if row_round_idx(row) != round_idx:
+            continue
+        v = row.get("train/loss")
+        if v is None or v == "":
+            v = row.get("loss")
+        if v is None or v == "":
+            continue
+        try:
+            vals.append(float(v))
+        except (TypeError, ValueError):
+            continue
+    if not vals:
+        return None
+    return sum(vals) / len(vals)
+
+
+def eval_accuracy_avg_for_round(
+    eval_list: List[Dict[str, Any]], round_idx: int
+) -> Optional[float]:
+    candidates: List[float] = []
+    for row in eval_list or []:
+        if not isinstance(row, dict):
+            continue
+        if row_round_idx(row) != round_idx:
+            continue
+        for k, v in row.items():
+            if not isinstance(k, str) or "accuracy" not in k.lower():
+                continue
+            if v is None or v == "":
+                continue
+            try:
+                candidates.append(float(v))
+            except (TypeError, ValueError):
+                continue
+    if not candidates:
+        return None
+    return sum(candidates) / len(candidates)
+
+
+def eval_loss_avg_for_round(
+    eval_list: List[Dict[str, Any]], round_idx: int
+) -> Optional[float]:
+    """Mean eval loss for ``round_idx`` (``eval/loss`` from MetricLogger)."""
+    vals: List[float] = []
+    for row in eval_list or []:
+        if not isinstance(row, dict):
+            continue
+        if row_round_idx(row) != round_idx:
+            continue
+        v = row.get("eval/loss")
+        if v is None or v == "":
+            v = row.get("loss")
+        if v is None or v == "":
+            continue
+        try:
+            vals.append(float(v))
+        except (TypeError, ValueError):
+            continue
+    if not vals:
+        return None
+    return sum(vals) / len(vals)
+
+
+def format_ms(v: Optional[float]) -> str:
+    if v is None or (isinstance(v, float) and (math.isnan(v) or math.isinf(v))):
+        return "—"
+    return f"{1000.0 * v:.2f}"

--- a/src/omnifed/summary/per_iteration.py
+++ b/src/omnifed/summary/per_iteration.py
@@ -1,0 +1,78 @@
+"""
+Universal per-iteration summary recording.
+
+Detects pipeline mode from config and installs the appropriate recorder.
+Classic is implemented today; hybrid will plug in here later.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from src.omnifed.summary.per_iteration_classic import (
+    ClassicIterationRecorder,
+    install_classic_iteration_recorder,
+)
+from src.omnifed.summary.pipeline import summary_mode_from_cfg
+
+__all__ = [
+    "ClassicIterationRecorder",
+    "accumulate_iter_comm",
+    "accumulate_classic_iter_comm",
+    "get_gpu_memory_snapshot_mb",
+    "install_iteration_recorder",
+    "install_classic_iteration_recorder",
+]
+
+
+def _iter_comm_bucket(logger: Any) -> Optional[dict]:
+    bucket = getattr(logger, "_summary_iter_comm", None)
+    if bucket is not None:
+        return bucket
+    legacy = getattr(logger, "_classic_iter_comm", None)
+    if legacy is not None:
+        return legacy
+    return None
+
+
+def accumulate_iter_comm(logger: Any, key: str, duration_sec: float) -> None:
+    """Sum wire timings into the active iteration bucket (when recorder enabled)."""
+    bucket = _iter_comm_bucket(logger)
+    if bucket is None:
+        return
+    bucket[key] = float(bucket.get(key, 0.0)) + float(duration_sec)
+
+
+def accumulate_classic_iter_comm(logger: Any, key: str, duration_sec: float) -> None:
+    """Backward-compatible alias for ``accumulate_iter_comm``."""
+    accumulate_iter_comm(logger, key, duration_sec)
+
+
+def get_gpu_memory_snapshot_mb():
+    from src.omnifed.summary.per_iteration_classic import get_gpu_memory_snapshot_mb as _fn
+
+    return _fn()
+
+
+def install_iteration_recorder(
+    cfg: Any,
+    algorithm: Any,
+    *,
+    rank: int,
+    log_dir: str,
+    comm_backend: str = "grpc",
+    aggregate_payload: str = "gradients",
+) -> Optional[ClassicIterationRecorder]:
+    """Install per-iteration CSV hooks for the pipeline implied by ``cfg``."""
+    mode = summary_mode_from_cfg(cfg)
+    if mode == "classic":
+        return install_classic_iteration_recorder(
+            algorithm,
+            rank=rank,
+            log_dir=log_dir,
+            comm_backend=comm_backend,
+            aggregate_payload=aggregate_payload,
+            mode=mode,
+        )
+    # Hybrid per-iteration CSV: not implemented yet.
+    return None

--- a/src/omnifed/summary/per_iteration_classic.py
+++ b/src/omnifed/summary/per_iteration_classic.py
@@ -1,0 +1,234 @@
+# Copyright (c) 2025, Oak Ridge National Laboratory.  All rights reserved.
+
+"""
+Classic centralized per-iteration CSV recorder.
+
+Used by the universal ``summary.per_iteration`` dispatcher when pipeline mode is ``classic``.
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+import time
+from typing import Any, Dict, Optional
+
+import torch
+
+_ITER_CSV_COLUMNS = [
+    "round_idx",
+    "epoch_idx",
+    "batch_idx",
+    "global_step",
+    "rank",
+    "batch_time_total_s",
+    "batch_time_data_s",
+    "batch_time_compute_s",
+    "train_loss",
+    "train_grad_norm",
+    "sync_time_total_s",
+    "grpc_agg_sample_s",
+    "grpc_agg_grad_s",
+    "grpc_agg_bn_s",
+    "grad_apply_s",
+    "grpc_upstream_s",
+    "grpc_downstream_s",
+    "grpc_compress_s",
+    "grpc_decompress_s",
+    "gpu_allocated_mb",
+    "gpu_reserved_mb",
+    "gpu_max_allocated_mb",
+    "gpu_max_reserved_mb",
+    "gpu_device_used_mb",
+    "gpu_device_total_mb",
+    "gpu_device_util_pct",
+    "comm_backend",
+    "aggregate_payload",
+]
+
+_COMM_KEYS = (
+    "grpc_upstream_s",
+    "grpc_downstream_s",
+    "grpc_compress_s",
+    "grpc_decompress_s",
+)
+
+_SYNC_KEYS = (
+    "grpc_agg_sample_time",
+    "grpc_agg_grad_time",
+    "grpc_agg_bn_time",
+    "grad_apply_time",
+)
+
+
+def per_iteration_csv_basename(rank: int, *, mode: str = "classic") -> str:
+    """Filename for per-rank per-iteration CSV (classic keeps historical name)."""
+    if mode == "classic":
+        return f"rank{int(rank)}_classic_per_iteration_summary.csv"
+    return f"rank{int(rank)}_per_iteration_summary.csv"
+
+
+def get_gpu_memory_snapshot_mb() -> Dict[str, Optional[float]]:
+    """GPU memory in MiB: PyTorch allocator stats + device-wide ``mem_get_info``."""
+    empty: Dict[str, Optional[float]] = {
+        "gpu_allocated_mb": None,
+        "gpu_reserved_mb": None,
+        "gpu_max_allocated_mb": None,
+        "gpu_max_reserved_mb": None,
+        "gpu_device_used_mb": None,
+        "gpu_device_total_mb": None,
+        "gpu_device_util_pct": None,
+    }
+    if not torch.cuda.is_available():
+        return empty
+    try:
+        device_idx = torch.cuda.current_device()
+        free_b, total_b = torch.cuda.mem_get_info(device_idx)
+        used_b = total_b - free_b
+        util_pct = (100.0 * used_b / total_b) if total_b > 0 else None
+        return {
+            "gpu_allocated_mb": torch.cuda.memory_allocated(device_idx) / (1024 ** 2),
+            "gpu_reserved_mb": torch.cuda.memory_reserved(device_idx) / (1024 ** 2),
+            "gpu_max_allocated_mb": torch.cuda.max_memory_allocated(device_idx) / (1024 ** 2),
+            "gpu_max_reserved_mb": torch.cuda.max_memory_reserved(device_idx) / (1024 ** 2),
+            "gpu_device_used_mb": used_b / (1024 ** 2),
+            "gpu_device_total_mb": total_b / (1024 ** 2),
+            "gpu_device_util_pct": util_pct,
+        }
+    except Exception:
+        return empty
+
+
+class ClassicIterationRecorder:
+    """Append one CSV row per training batch on each rank (classic centralized)."""
+
+    def __init__(
+        self,
+        *,
+        rank: int,
+        log_dir: str,
+        comm_backend: str = "grpc",
+        aggregate_payload: str = "gradients",
+        mode: str = "classic",
+    ) -> None:
+        self.rank = int(rank)
+        self.log_dir = log_dir
+        self.comm_backend = str(comm_backend)
+        self.aggregate_payload = str(aggregate_payload)
+        self.mode = str(mode)
+        os.makedirs(log_dir, exist_ok=True)
+        self.csv_path = os.path.join(
+            log_dir, per_iteration_csv_basename(self.rank, mode=self.mode)
+        )
+        self._header_written = os.path.isfile(self.csv_path) and os.path.getsize(
+            self.csv_path
+        ) > 0
+
+    def reset_batch(self, algorithm: Any) -> None:
+        algorithm._summary_iter_comm = {k: 0.0 for k in _COMM_KEYS}
+        algorithm._summary_iter_sync = {}
+        algorithm._summary_iter_batch_t0 = time.perf_counter()
+        algorithm._summary_iter_train = {}
+
+    def record_after_batch(self, algorithm: Any) -> None:
+        """Write one row; call from ``_train_batch_end`` after sync."""
+        batch_t0 = getattr(algorithm, "_summary_iter_batch_t0", None)
+        batch_time_total_s = (
+            time.perf_counter() - batch_t0 if batch_t0 is not None else None
+        )
+
+        peek = getattr(algorithm, "peek_metric", None)
+        batch_time_data_s = (
+            peek("batch_time_data", agg_context="train") if peek else None
+        )
+        batch_time_compute_s = (
+            peek("batch_time_compute", agg_context="train") if peek else None
+        )
+
+        train_state = getattr(algorithm, "_summary_iter_train", {}) or {}
+        train_loss = train_state.get("loss")
+        train_grad_norm = train_state.get("grad_norm")
+
+        sync_times: Dict[str, float] = getattr(algorithm, "_summary_iter_sync", {}) or {}
+        comm_times: Dict[str, float] = getattr(algorithm, "_summary_iter_comm", {}) or {}
+
+        sync_parts = [float(sync_times.get(k, 0.0) or 0.0) for k in _SYNC_KEYS]
+        sync_time_total_s = sum(sync_parts) if any(sync_parts) else None
+
+        gpu = get_gpu_memory_snapshot_mb()
+
+        row = {
+            "round_idx": int(getattr(algorithm, "round_idx", -1)),
+            "epoch_idx": int(getattr(algorithm, "epoch_idx", -1)),
+            "batch_idx": int(getattr(algorithm, "batch_idx", -1)),
+            "global_step": int(getattr(algorithm, "experiment_batch_idx", -1)),
+            "rank": self.rank,
+            "batch_time_total_s": _fmt(batch_time_total_s),
+            "batch_time_data_s": _fmt(batch_time_data_s),
+            "batch_time_compute_s": _fmt(batch_time_compute_s),
+            "train_loss": _fmt(train_loss),
+            "train_grad_norm": _fmt(train_grad_norm),
+            "sync_time_total_s": _fmt(sync_time_total_s),
+            "grpc_agg_sample_s": _fmt(sync_times.get("grpc_agg_sample_time")),
+            "grpc_agg_grad_s": _fmt(sync_times.get("grpc_agg_grad_time")),
+            "grpc_agg_bn_s": _fmt(sync_times.get("grpc_agg_bn_time")),
+            "grad_apply_s": _fmt(sync_times.get("grad_apply_time")),
+            "grpc_upstream_s": _fmt(comm_times.get("grpc_upstream_s")),
+            "grpc_downstream_s": _fmt(comm_times.get("grpc_downstream_s")),
+            "grpc_compress_s": _fmt(comm_times.get("grpc_compress_s")),
+            "grpc_decompress_s": _fmt(comm_times.get("grpc_decompress_s")),
+            **{k: _fmt(v) for k, v in gpu.items()},
+            "comm_backend": self.comm_backend,
+            "aggregate_payload": self.aggregate_payload,
+        }
+
+        with open(self.csv_path, "a", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=_ITER_CSV_COLUMNS)
+            if not self._header_written:
+                writer.writeheader()
+                self._header_written = True
+            writer.writerow(row)
+
+
+def _fmt(val: Any) -> str:
+    if val is None:
+        return ""
+    if isinstance(val, float):
+        return f"{val:.6f}"
+    return str(val)
+
+
+def install_classic_iteration_recorder(
+    algorithm: Any,
+    *,
+    rank: int,
+    log_dir: str,
+    comm_backend: str = "grpc",
+    aggregate_payload: str = "gradients",
+    mode: str = "classic",
+) -> ClassicIterationRecorder:
+    """Attach batch hooks and store recorder on ``algorithm``."""
+    recorder = ClassicIterationRecorder(
+        rank=rank,
+        log_dir=log_dir,
+        comm_backend=comm_backend,
+        aggregate_payload=aggregate_payload,
+        mode=mode,
+    )
+    algorithm._summary_iteration_recorder = recorder
+
+    base_batch_start = algorithm._train_batch_start
+    base_batch_end = algorithm._train_batch_end
+
+    def _train_batch_start(self) -> None:
+        recorder.reset_batch(self)
+        base_batch_start()
+
+    def _train_batch_end(self) -> None:
+        base_batch_end()
+        recorder.record_after_batch(self)
+
+    algorithm._train_batch_start = _train_batch_start.__get__(algorithm, type(algorithm))
+    algorithm._train_batch_end = _train_batch_end.__get__(algorithm, type(algorithm))
+
+    return recorder

--- a/src/omnifed/summary/pipeline.py
+++ b/src/omnifed/summary/pipeline.py
@@ -1,0 +1,17 @@
+"""Resolve training pipeline mode for summary generation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.omnifed.engine_communication import communication_mode
+
+_SUMMARY_MODES = ("classic", "hybrid")
+
+
+def summary_mode_from_cfg(cfg: Any) -> str:
+    """Return ``classic`` or ``hybrid`` from ``engine.communication_mode``."""
+    mode = communication_mode(cfg)
+    if mode not in _SUMMARY_MODES:
+        raise ValueError(f"unsupported summary pipeline mode: {mode!r}")
+    return mode

--- a/src/omnifed/summary/slurm_per_round.py
+++ b/src/omnifed/summary/slurm_per_round.py
@@ -1,0 +1,277 @@
+"""
+Universal Slurm post-run per-round summary.
+
+Single execution entry for classic centralized and hybrid training pipelines.
+Polls ``metrics_full.csv`` / ``node_results``, builds mode-specific tables, writes artifacts.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import time
+from typing import Any, Optional, Sequence, Tuple
+
+from src.omnifed.summary.pipeline import summary_mode_from_cfg
+from src.omnifed.summary.classic_per_round import build_classic_per_round_tables
+from src.omnifed.summary.hybrid_per_round import build_hybrid_per_round_tables
+from src.omnifed.summary.metrics_full import (
+    enrich_payloads_from_metrics_full,
+    merge_json_payloads_into,
+    payloads_from_metrics_full_for_trainers,
+    trainers_metrics_full_ready,
+    warn_if_summary_missing_eval,
+)
+
+__all__ = [
+    "write_slurm_per_round_summary",
+    "write_slurm_per_round_summary_for_run",
+    "write_classic_slurm_per_round_summary",
+    "write_hybrid_slurm_per_round_summary",
+]
+
+_SUMMARY_MODES = ("classic", "hybrid")
+
+
+def _poll_settings(mode: str, world_size: int) -> Tuple[float, float]:
+    default_timeout = str(max(90.0, 5.0 * float(world_size)))
+    if mode == "classic":
+        timeout_s = float(
+            os.environ.get(
+                "OMNIFED_CLASSIC_SUMMARY_POLL_SEC",
+                os.environ.get("OMNIFED_HYBRID_SUMMARY_POLL_SEC", default_timeout),
+            )
+        )
+        poll_gap = float(
+            os.environ.get(
+                "OMNIFED_CLASSIC_SUMMARY_POLL_GAP_SEC",
+                os.environ.get("OMNIFED_HYBRID_SUMMARY_POLL_GAP_SEC", "0.5"),
+            )
+        )
+    else:
+        timeout_s = float(
+            os.environ.get("OMNIFED_HYBRID_SUMMARY_POLL_SEC", default_timeout)
+        )
+        poll_gap = float(os.environ.get("OMNIFED_HYBRID_SUMMARY_POLL_GAP_SEC", "0.5"))
+    return timeout_s, poll_gap
+
+
+def _poll_timeout_env_name(mode: str) -> str:
+    if mode == "classic":
+        return "OMNIFED_CLASSIC_SUMMARY_POLL_SEC"
+    return "OMNIFED_HYBRID_SUMMARY_POLL_SEC"
+
+
+def _trainer_ranks(world_size: int, rpc_server_rank: int) -> Tuple[int, ...]:
+    return tuple(gr for gr in range(int(world_size)) if gr != int(rpc_server_rank))
+
+
+def _wait_for_summary_inputs(
+    *,
+    mode: str,
+    hydra_out_dir: str,
+    trainer_ranks: Sequence[int],
+    world_size: int,
+    rpc_server_rank: int,
+) -> bool:
+    rd = os.path.join(hydra_out_dir, "engine", "node_results")
+    if not os.path.isdir(rd):
+        print(
+            f"[{mode}] summary: missing {rd} — pass the Hydra run directory "
+            "(outputs/DATE/your_job_name/).",
+            flush=True,
+        )
+        return False
+
+    timeout_s, poll_gap = _poll_settings(mode, world_size)
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        njson = len(glob.glob(os.path.join(rd, "node_*_results.json")))
+        nfull = trainers_metrics_full_ready(
+            hydra_out_dir,
+            trainer_ranks=trainer_ranks,
+            rpc_server_rank=int(rpc_server_rank),
+            world_size=int(world_size),
+        )
+        if njson >= int(world_size) or nfull >= len(trainer_ranks):
+            return True
+        time.sleep(poll_gap)
+
+    njson = len(glob.glob(os.path.join(rd, "node_*_results.json")))
+    nfull = trainers_metrics_full_ready(
+        hydra_out_dir,
+        trainer_ranks=trainer_ranks,
+        rpc_server_rank=int(rpc_server_rank),
+        world_size=int(world_size),
+    )
+    print(
+        f"[{mode}] summary: timeout ({njson}/{world_size} JSON, "
+        f"{nfull}/{len(trainer_ranks)} metrics_full). "
+        f"Raise {_poll_timeout_env_name(mode)}.",
+        flush=True,
+    )
+    return False
+
+
+def _write_summary_artifacts(
+    *,
+    mode: str,
+    hydra_out_dir: str,
+    md_txt: str,
+    csv_txt: str,
+) -> str:
+    eng = os.path.join(hydra_out_dir, "engine")
+    txt_path = os.path.join(eng, f"{mode}_per_round_summary.txt")
+    csv_path_engine = os.path.join(eng, f"{mode}_per_round_summary.csv")
+    csv_path_run = os.path.join(hydra_out_dir, f"{mode}_per_round_summary.csv")
+
+    os.makedirs(eng, exist_ok=True)
+    with open(txt_path, "w", encoding="utf-8") as ftxt:
+        ftxt.write(md_txt)
+
+    for cp in (csv_path_engine, csv_path_run):
+        with open(cp, "w", encoding="utf-8", newline="") as fc:
+            fc.write(csv_txt)
+
+    print(
+        f"[{mode}] per-round summary: engine/{mode}_per_round_summary.{{txt,csv}} "
+        f"+ {mode}_per_round_summary.csv (run root)",
+        flush=True,
+    )
+    print(md_txt.strip(), flush=True)
+    return txt_path
+
+
+def write_slurm_per_round_summary(
+    hydra_out_dir: str,
+    *,
+    mode: str,
+    world_size: int,
+    rpc_server_rank: int = 0,
+    rank_writer: int,
+    topo: Any = None,
+) -> Optional[str]:
+    """Poll trainer metrics and write per-round summary for ``mode`` (classic or hybrid)."""
+    _ = rank_writer
+    mode_norm = str(mode).lower()
+    if mode_norm not in _SUMMARY_MODES:
+        raise ValueError(f"summary mode must be one of {_SUMMARY_MODES}, got {mode!r}")
+    if mode_norm == "hybrid" and topo is None:
+        raise ValueError("topo is required when mode='hybrid'")
+
+    trainer_ranks = _trainer_ranks(world_size, rpc_server_rank)
+    if not trainer_ranks:
+        print(f"[{mode_norm}] summary: no client trainer ranks", flush=True)
+        return None
+
+    if not _wait_for_summary_inputs(
+        mode=mode_norm,
+        hydra_out_dir=hydra_out_dir,
+        trainer_ranks=trainer_ranks,
+        world_size=world_size,
+        rpc_server_rank=rpc_server_rank,
+    ):
+        return None
+
+    contexts = ("sync", "eval", "train") if mode_norm == "classic" else ("sync", "eval")
+    payloads = payloads_from_metrics_full_for_trainers(
+        hydra_out_dir,
+        trainer_ranks=trainer_ranks,
+        rpc_server_rank=int(rpc_server_rank),
+        world_size=int(world_size),
+        contexts=contexts,
+    )
+    merge_json_payloads_into(payloads, hydra_out_dir)
+    enrich_payloads_from_metrics_full(
+        hydra_out_dir,
+        payloads,
+        trainer_ranks=trainer_ranks,
+        rpc_server_rank=int(rpc_server_rank),
+        world_size=int(world_size),
+        contexts=contexts,
+    )
+
+    if mode_norm == "classic":
+        md_txt, csv_txt = build_classic_per_round_tables(
+            payloads=payloads,
+            trainer_ranks=trainer_ranks,
+        )
+    else:
+        md_txt, csv_txt = build_hybrid_per_round_tables(
+            topo=topo,
+            payloads=payloads,
+            trainer_ranks=trainer_ranks,
+        )
+
+    warn_if_summary_missing_eval(
+        mode=mode_norm,
+        hydra_out_dir=hydra_out_dir,
+        trainer_ranks=trainer_ranks,
+        rpc_server_rank=int(rpc_server_rank),
+        world_size=int(world_size),
+        csv_txt=csv_txt,
+    )
+
+    return _write_summary_artifacts(
+        mode=mode_norm,
+        hydra_out_dir=hydra_out_dir,
+        md_txt=md_txt,
+        csv_txt=csv_txt,
+    )
+
+
+def write_slurm_per_round_summary_for_run(
+    cfg: Any,
+    hydra_out_dir: str,
+    *,
+    world_size: int,
+    rpc_server_rank: int = 0,
+    rank_writer: int,
+    topo: Any = None,
+) -> Optional[str]:
+    """Detect pipeline from ``cfg`` and write the matching per-round summary."""
+    mode = summary_mode_from_cfg(cfg)
+    if mode == "hybrid" and topo is None:
+        raise ValueError("topo is required when engine.communication_mode='hybrid'")
+    return write_slurm_per_round_summary(
+        hydra_out_dir,
+        mode=mode,
+        world_size=world_size,
+        rpc_server_rank=rpc_server_rank,
+        rank_writer=rank_writer,
+        topo=topo,
+    )
+
+
+def write_classic_slurm_per_round_summary(
+    hydra_out_dir: str,
+    *,
+    world_size: int,
+    rpc_server_rank: int = 0,
+    rank_writer: int,
+) -> Optional[str]:
+    return write_slurm_per_round_summary(
+        hydra_out_dir,
+        mode="classic",
+        world_size=world_size,
+        rpc_server_rank=rpc_server_rank,
+        rank_writer=rank_writer,
+    )
+
+
+def write_hybrid_slurm_per_round_summary(
+    hydra_out_dir: str,
+    *,
+    topo: Any,
+    world_size: int,
+    rpc_server_rank: int,
+    rank_writer: int,
+) -> Optional[str]:
+    return write_slurm_per_round_summary(
+        hydra_out_dir,
+        mode="hybrid",
+        world_size=world_size,
+        rpc_server_rank=rpc_server_rank,
+        rank_writer=rank_writer,
+        topo=topo,
+    )

--- a/tests/test_classic_grad_slurm.py
+++ b/tests/test_classic_grad_slurm.py
@@ -1,0 +1,33 @@
+"""Regression: classic synchronous grad hooks."""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from src.omnifed.classic.classic_grad_slurm import install_classic_grad_slurm_sync
+
+
+class TestClassicGradSlurmHooks(unittest.TestCase):
+    def test_round_start_calls_base_once(self) -> None:
+        calls: list[str] = []
+
+        class Algo(SimpleNamespace):
+            def _base_round_start(self) -> None:
+                calls.append("base")
+
+        algo = Algo()
+        algo._round_start = algo._base_round_start
+        algo._BaseAlgorithm__local_optimizer = mock.Mock()
+        algo.local_comm = mock.Mock()
+
+        install_classic_grad_slurm_sync(algo, local_comm=algo.local_comm)
+        algo._round_start()
+
+        self.assertEqual(calls, ["base"])
+        algo._BaseAlgorithm__local_optimizer.zero_grad.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_classic_per_iteration_summary.py
+++ b/tests/test_classic_per_iteration_summary.py
@@ -1,0 +1,107 @@
+"""Unit tests for classic per-iteration CSV recorder."""
+
+from __future__ import annotations
+
+import csv
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from src.omnifed.summary.per_iteration import (
+    ClassicIterationRecorder,
+    accumulate_iter_comm,
+    install_classic_iteration_recorder,
+)
+
+
+class TestClassicPerIterationSummary(unittest.TestCase):
+    def test_accumulate_iter_comm(self) -> None:
+        algo = SimpleNamespace(_summary_iter_comm={"grpc_upstream_s": 1.0})
+        accumulate_iter_comm(algo, "grpc_upstream_s", 0.5)
+        self.assertAlmostEqual(algo._summary_iter_comm["grpc_upstream_s"], 1.5)
+
+    def test_accumulate_iter_comm_legacy_bucket(self) -> None:
+        algo = SimpleNamespace(_classic_iter_comm={"grpc_upstream_s": 1.0})
+        accumulate_iter_comm(algo, "grpc_upstream_s", 0.5)
+        self.assertAlmostEqual(algo._classic_iter_comm["grpc_upstream_s"], 1.5)
+
+    def test_record_after_batch_writes_csv(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            recorder = ClassicIterationRecorder(rank=2, log_dir=tmp)
+            algo = SimpleNamespace(
+                round_idx=0,
+                epoch_idx=1,
+                batch_idx=3,
+                experiment_batch_idx=42,
+                _summary_iter_batch_t0=None,
+                _summary_iter_train={"loss": 1.25, "grad_norm": 0.5},
+                _summary_iter_sync={
+                    "grpc_agg_sample_time": 0.01,
+                    "grpc_agg_grad_time": 1.2,
+                    "grpc_agg_bn_time": 0.3,
+                    "grad_apply_time": 0.001,
+                },
+                _summary_iter_comm={
+                    "grpc_upstream_s": 0.8,
+                    "grpc_downstream_s": 0.7,
+                    "grpc_compress_s": 0.05,
+                    "grpc_decompress_s": 0.02,
+                },
+            )
+            algo.peek_metric = mock.Mock(
+                side_effect=lambda key, agg_context=None: {
+                    ("batch_time_data", "train"): 0.01,
+                    ("batch_time_compute", "train"): 0.4,
+                }.get((key, agg_context))
+            )
+
+            with mock.patch(
+                "src.omnifed.summary.per_iteration_classic.get_gpu_memory_snapshot_mb",
+                return_value={
+                    "gpu_allocated_mb": 100.0,
+                    "gpu_reserved_mb": 128.0,
+                    "gpu_max_allocated_mb": 150.0,
+                    "gpu_max_reserved_mb": 160.0,
+                    "gpu_device_used_mb": 8192.0,
+                    "gpu_device_total_mb": 65536.0,
+                    "gpu_device_util_pct": 12.5,
+                },
+            ):
+                recorder.record_after_batch(algo)
+
+            csv_path = os.path.join(tmp, "rank2_classic_per_iteration_summary.csv")
+            self.assertTrue(os.path.isfile(csv_path))
+            with open(csv_path, encoding="utf-8") as f:
+                rows = list(csv.DictReader(f))
+            self.assertEqual(len(rows), 1)
+            row = rows[0]
+            self.assertEqual(row["rank"], "2")
+            self.assertEqual(row["batch_idx"], "3")
+            self.assertEqual(row["train_loss"], "1.250000")
+            self.assertEqual(row["grpc_agg_grad_s"], "1.200000")
+            self.assertEqual(row["grpc_upstream_s"], "0.800000")
+            self.assertAlmostEqual(float(row["sync_time_total_s"]), 1.511)
+            self.assertEqual(row["gpu_device_used_mb"], "8192.000000")
+            self.assertEqual(row["gpu_device_total_mb"], "65536.000000")
+            self.assertEqual(row["gpu_device_util_pct"], "12.500000")
+
+    def test_install_hooks(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            class Algo(SimpleNamespace):
+                def _train_batch_start(self) -> None:
+                    pass
+
+                def _train_batch_end(self) -> None:
+                    pass
+
+            algo = Algo()
+            install_classic_iteration_recorder(algo, rank=0, log_dir=tmp)
+            self.assertTrue(hasattr(algo, "_summary_iteration_recorder"))
+            algo._train_batch_start()
+            self.assertIn("grpc_upstream_s", algo._summary_iter_comm)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_classic_run_summary.py
+++ b/tests/test_classic_run_summary.py
@@ -1,0 +1,76 @@
+"""Unit tests for classic centralized per-round summary (``summary`` package)."""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from src.omnifed.summary.slurm_per_round import write_classic_slurm_per_round_summary
+
+
+class TestClassicRunSummary(unittest.TestCase):
+    def test_build_and_write_round_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            hydra = Path(tmp)
+            nr = hydra / "engine" / "node_results"
+            nr.mkdir(parents=True)
+
+            (nr / "node_000_results.json").write_text(
+                json.dumps({"role": "grpc_server", "rank": 0}),
+                encoding="utf-8",
+            )
+
+            for gr in range(1, 4):
+                node_dir = hydra / f"Node0.{gr}"
+                node_dir.mkdir(parents=True)
+                full = node_dir / "metrics_full.csv"
+                with open(full, "w", encoding="utf-8", newline="") as f:
+                    w = csv.writer(f)
+                    w.writerow(
+                        [
+                            "global_step",
+                            "round_idx",
+                            "epoch_idx",
+                            "batch_idx",
+                            "agg_ctx",
+                            "metric_key",
+                            "metric_val",
+                        ]
+                    )
+                    w.writerow([100, 0, 0, 0, "sync", "local_agg_time", 0.05 + gr * 0.01])
+                    w.writerow([101, 0, 0, 1, "sync", "local_agg_time", 0.03 + gr * 0.01])
+                    w.writerow([200, 0, 0, 0, "sync", "grad_apply_time", 0.002])
+                    w.writerow([300, 0, 0, 0, "eval", "eval/loss", 2.5 - gr * 0.1])
+                    w.writerow([400, 0, 3, 10, "train", "train/loss", 1.2 - gr * 0.05])
+
+                (nr / f"node_{gr:03d}_results.json").write_text(
+                    json.dumps({"rank": gr}),
+                    encoding="utf-8",
+                )
+
+            out = write_classic_slurm_per_round_summary(
+                str(hydra),
+                world_size=4,
+                rpc_server_rank=0,
+                rank_writer=1,
+            )
+            self.assertIsNotNone(out)
+
+            csv_path = hydra / "classic_per_round_summary.csv"
+            self.assertTrue(csv_path.is_file())
+            with open(csv_path, encoding="utf-8") as f:
+                rows = list(csv.DictReader(f))
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]["round_idx"], "0")
+            self.assertEqual(rows[0]["grpc_agg_max_ms"], "80.00")
+            self.assertEqual(rows[0]["n_eval_trainers"], "3")
+            self.assertAlmostEqual(float(rows[0]["eval_loss_avg"]), 2.3, places=4)
+            self.assertAlmostEqual(float(rows[0]["train_loss_avg"]), 1.1, places=4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_engine_slurm_frozen_cfg.py
+++ b/tests/test_engine_slurm_frozen_cfg.py
@@ -1,0 +1,25 @@
+"""Slurm frozen config path (per-run, not shared outputs/engine_frozen.json)."""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+from src.omnifed.slurm_launcher import resolve_slurm_frozen_cfg_path
+
+
+class TestResolveSlurmFrozenCfgPath(unittest.TestCase):
+    def test_under_hydra_run_dir_not_shared_outputs_root(self) -> None:
+        run_dir = "/tmp/outputs/2026-08-06_14-54-05/test_pi_centralized_sync_param_grpc"
+        path = resolve_slurm_frozen_cfg_path(run_dir)
+        self.assertEqual(path, os.path.join(run_dir, "engine_frozen.json"))
+        self.assertNotEqual(os.path.dirname(path), os.path.dirname(os.path.dirname(run_dir)))
+
+    def test_two_runs_get_distinct_paths(self) -> None:
+        a = resolve_slurm_frozen_cfg_path("/tmp/outputs/2026-08-06_14-54-05/run_a")
+        b = resolve_slurm_frozen_cfg_path("/tmp/outputs/2026-08-06_14-56-28/run_b")
+        self.assertNotEqual(a, b)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_grpc_grad_buffers.py
+++ b/tests/test_grpc_grad_buffers.py
@@ -1,0 +1,57 @@
+"""Grad-mode gRPC must not aggregate BN buffers with parameter gradients."""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+import torch.nn as nn
+
+from src.omnifed.communicator.grpc import GrpcCommunicator
+
+
+class _TinyBn(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.lin = nn.Linear(4, 2)
+        self.bn = nn.BatchNorm1d(2)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.bn(self.lin(x))
+
+
+class TestGrpcGradBufferExclusion(unittest.TestCase):
+    def test_extract_skips_buffers_when_communicating_grads(self) -> None:
+        comm = GrpcCommunicator(
+            rank=1,
+            world_size=2,
+            master_port=50051,
+            communicate_params=False,
+        )
+        model = _TinyBn()
+        model.lin.weight.grad = torch.ones_like(model.lin.weight)
+
+        extracted = comm._extract_tensordict_from_msg(model)
+
+        self.assertIn("lin.weight", extracted)
+        self.assertNotIn("bn.running_mean", extracted)
+        self.assertNotIn("bn.running_var", extracted)
+
+    def test_extract_includes_buffers_for_param_fedavg(self) -> None:
+        comm = GrpcCommunicator(
+            rank=1,
+            world_size=2,
+            master_port=50052,
+            communicate_params=True,
+        )
+        model = _TinyBn()
+
+        extracted = comm._extract_tensordict_from_msg(model)
+
+        self.assertIn("lin.weight", extracted)
+        self.assertIn("bn.running_mean", extracted)
+        self.assertIn("bn.running_var", extracted)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_grpc_qsgd_classic.py
+++ b/tests/test_grpc_qsgd_classic.py
@@ -1,0 +1,82 @@
+"""Classic gRPC QSGD roundtrip for sync grad aggregation."""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from src.omnifed.communicator.base import AggregationOp
+from src.omnifed.communicator.compression.quantization import QSGDQuantCompression
+from src.omnifed.communicator.grpc_server import GrpcServer
+from src.omnifed.communicator.utils import (
+    compress_message_tensors,
+    compressor_proto_name,
+    proto_to_tensordict_extended,
+    tensordict_to_proto,
+)
+
+
+class TestGrpcQsgdClassicSyncGrad(unittest.TestCase):
+    def setUp(self) -> None:
+        torch.manual_seed(0)
+        self.compressor = QSGDQuantCompression(device="cpu", bit_width=4)
+
+    def test_proto_roundtrip_per_tensor(self) -> None:
+        grad = torch.tensor([1.0, -2.0, 0.5, 3.0])
+        compressed = compress_message_tensors(
+            {"w": grad}, self.compressor, "grad"
+        )
+        proto = tensordict_to_proto(compressed, compressor_proto_name(self.compressor))
+        decoded, _ = proto_to_tensordict_extended(proto, overlay_base=None)
+        self.assertEqual(decoded["w"].shape, grad.shape)
+        self.assertTrue(torch.isfinite(decoded["w"]).all())
+
+    def test_uplink_proto_roundtrip_then_server_sum(self) -> None:
+        g1 = torch.tensor([1.0, 0.0, -2.0, 3.0])
+        g2 = torch.tensor([0.5, 1.5, 2.0, -1.0])
+        dense_clients = []
+        for grad in (g1, g2):
+            compressed = compress_message_tensors(
+                {"w": grad}, self.compressor, "grad"
+            )
+            proto = tensordict_to_proto(
+                compressed, compressor_proto_name(self.compressor)
+            )
+            decoded, _ = proto_to_tensordict_extended(proto, overlay_base=None)
+            dense_clients.append(decoded["w"])
+
+        summed = dense_clients[0] + dense_clients[1]
+        server = GrpcServer(world_size=3, communicate_params=False)
+        session_id = server.current_aggregation_session
+        session_state = server.aggregation_state[session_id]
+        session_state["reduction_type"] = AggregationOp.SUM.value
+        session_state["data"] = {
+            "server": {"w": torch.zeros_like(g1)},
+            "1": {"w": dense_clients[0]},
+            "2": {"w": dense_clients[1]},
+        }
+        self.assertTrue(
+            server.perform_aggregation_if_ready(session_state, session_id)
+        )
+        torch.testing.assert_close(session_state["result"]["w"], summed)
+
+    def test_dense_payload_when_compressor_none(self) -> None:
+        bn = torch.tensor([0.1, 0.2, 0.3, 0.4])
+        payload = {"running_mean": bn}
+        dense = compress_message_tensors(payload, None, "grad")
+        self.assertIs(dense["running_mean"], bn)
+
+    def test_decompress_quantized_inverse(self) -> None:
+        grad = torch.randn(8)
+        signed, norm, width, levels = self.compressor.compress(grad.clone(), "w")
+        self.assertNotEqual(width, -1)
+        restored = QSGDQuantCompression.decompress_quantized(
+            signed, norm, levels, grad.shape
+        )
+        self.assertEqual(restored.shape, grad.shape)
+        self.assertTrue(torch.isfinite(restored).all())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_grpc_server_sample_weighted.py
+++ b/tests/test_grpc_server_sample_weighted.py
@@ -1,0 +1,112 @@
+"""GrpcServer sample-weighted aggregation for classic grad Path B."""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from src.omnifed.communicator.base import AggregationOp
+from src.omnifed.communicator.grpc_server import GrpcServer
+
+
+class TestGrpcServerSampleWeighted(unittest.TestCase):
+    def test_sum_divides_by_total_samples_when_enabled(self) -> None:
+        server = GrpcServer(
+            world_size=2,
+            normalize_by_total_samples=True,
+            communicate_params=False,
+        )
+        session_id = server.current_aggregation_session
+        session_state = server.aggregation_state[session_id]
+        session_state["reduction_type"] = AggregationOp.SUM.value
+        session_state["data"] = {
+            "1": {"w": torch.tensor([2.0, 4.0])},
+            "2": {"w": torch.tensor([4.0, 8.0])},
+        }
+        session_state["total_samples"] = 100
+
+        done = server.perform_aggregation_if_ready(session_state, session_id)
+        self.assertTrue(done)
+        result = session_state["result"]["w"]
+        torch.testing.assert_close(result, torch.tensor([0.06, 0.12]))
+
+
+    def test_sum_skips_normalize_when_no_sample_count(self) -> None:
+        """Epoch-heartbeat scalar SUM has total_samples=0; leave unnormalized."""
+        server = GrpcServer(
+            world_size=2,
+            normalize_by_total_samples=True,
+            communicate_params=False,
+        )
+        session_id = server.current_aggregation_session
+        session_state = server.aggregation_state[session_id]
+        session_state["reduction_type"] = AggregationOp.SUM.value
+        session_state["data"] = {
+            "1": {"signal": torch.tensor([1.0])},
+            "2": {"signal": torch.tensor([1.0])},
+        }
+        session_state["total_samples"] = 0
+
+        done = server.perform_aggregation_if_ready(session_state, session_id)
+        self.assertTrue(done)
+        torch.testing.assert_close(
+            session_state["result"]["signal"], torch.tensor([2.0])
+        )
+
+    def test_reset_partial_session_on_reduction_mismatch(self) -> None:
+        server = GrpcServer(world_size=3, communicate_params=False)
+        sid = server.current_aggregation_session
+        st = server.aggregation_state[sid]
+        st["reduction_type"] = AggregationOp.MAX.value
+        st["data"]["1"] = {"x": torch.tensor([1.0])}
+
+        server._reset_aggregation_session(sid)
+        self.assertIsNone(st["reduction_type"])
+        self.assertEqual(st["data"], {})
+        self.assertEqual(st["total_samples"], 0)
+
+    def test_aggregation_clears_submitted_inputs(self) -> None:
+        server = GrpcServer(world_size=2, communicate_params=False)
+        session_id = server.current_aggregation_session
+        session_state = server.aggregation_state[session_id]
+        session_state["reduction_type"] = AggregationOp.SUM.value
+        session_state["data"] = {
+            "1": {"w": torch.tensor([1.0])},
+            "2": {"w": torch.tensor([3.0])},
+        }
+
+        done = server.perform_aggregation_if_ready(session_state, session_id)
+        self.assertTrue(done)
+        self.assertEqual(session_state["data"], {})
+        self.assertEqual(session_state["participants"], {"1", "2"})
+        torch.testing.assert_close(
+            session_state["result"]["w"], torch.tensor([4.0])
+        )
+
+    def test_session_dropped_after_all_participants_fetch(self) -> None:
+        server = GrpcServer(world_size=3, communicate_params=False)
+        session_id = server.current_aggregation_session
+        session_state = server.aggregation_state[session_id]
+        session_state["reduction_type"] = AggregationOp.SUM.value
+        session_state["data"] = {
+            "server": {"w": torch.tensor([0.0])},
+            "1": {"w": torch.tensor([1.0])},
+            "2": {"w": torch.tensor([2.0])},
+        }
+
+        self.assertTrue(
+            server.perform_aggregation_if_ready(session_state, session_id)
+        )
+        self.assertIn(session_id, server.aggregation_state)
+
+        server.mark_aggregation_result_delivered(session_id, "server")
+        server.mark_aggregation_result_delivered(session_id, "1")
+        self.assertIn(session_id, server.aggregation_state)
+
+        server.mark_aggregation_result_delivered(session_id, "2")
+        self.assertNotIn(session_id, server.aggregation_state)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_grpc_topk_classic.py
+++ b/tests/test_grpc_topk_classic.py
@@ -1,0 +1,94 @@
+"""Classic gRPC Top-K roundtrip for sync grad aggregation."""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from src.omnifed.communicator.base import AggregationOp
+from src.omnifed.communicator.compression.sparsification import TopKCompression
+from src.omnifed.communicator.grpc_server import GrpcServer
+from src.omnifed.communicator.utils import (
+    compress_message_tensors,
+    compressor_proto_name,
+    proto_to_tensordict_extended,
+    tensordict_to_proto,
+)
+
+
+class TestGrpcTopkClassicSyncGrad(unittest.TestCase):
+    def setUp(self) -> None:
+        self.compressor = TopKCompression(device="cpu", compress_ratio=0.25)
+
+    def test_zero_base_decode_not_local_grad_overlay(self) -> None:
+        local_grad = torch.tensor([1.0, 2.0, 3.0, 4.0])
+        (values, indices), ctx = self.compressor.compress(local_grad.clone(), "w")
+        compressed = {
+            "w": {
+                "values": values,
+                "indices": indices,
+                "original_shape": local_grad.shape,
+                "ctx": ctx,
+            }
+        }
+        proto = tensordict_to_proto(compressed, compressor_proto_name(self.compressor))
+
+        decoded, _ = proto_to_tensordict_extended(proto, overlay_base=None)
+        wrong, _ = proto_to_tensordict_extended(proto, overlay_base={"w": local_grad})
+
+        expected = self.compressor.decompress((values, indices), ctx)
+        torch.testing.assert_close(decoded["w"], expected)
+        self.assertFalse(torch.allclose(decoded["w"], wrong["w"]))
+
+    def test_uplink_proto_roundtrip_then_server_sum(self) -> None:
+        g1 = torch.tensor([1.0, 0.0, -2.0, 3.0])
+        g2 = torch.tensor([0.5, 1.5, 2.0, -1.0])
+        grads = {"w": g1}, {"w": g2}
+
+        dense_clients = []
+        for grad in grads:
+            compressed = compress_message_tensors(grad, self.compressor, "grad")
+            proto = tensordict_to_proto(compressed, compressor_proto_name(self.compressor))
+            decoded, _ = proto_to_tensordict_extended(proto, overlay_base=None)
+            dense_clients.append(decoded["w"])
+
+        summed = dense_clients[0] + dense_clients[1]
+        self.assertEqual(summed.shape, g1.shape)
+
+        server = GrpcServer(world_size=3, communicate_params=False)
+        session_id = server.current_aggregation_session
+        session_state = server.aggregation_state[session_id]
+        session_state["reduction_type"] = AggregationOp.SUM.value
+        session_state["data"] = {
+            "server": {"w": torch.zeros_like(g1)},
+            "1": {"w": dense_clients[0]},
+            "2": {"w": dense_clients[1]},
+        }
+        self.assertTrue(
+            server.perform_aggregation_if_ready(session_state, session_id)
+        )
+        torch.testing.assert_close(session_state["result"]["w"], summed)
+
+    def test_downlink_proto_roundtrip(self) -> None:
+        aggregated = torch.tensor([1.5, 1.5, 0.0, 2.0])
+        compressed = compress_message_tensors(
+            {"w": aggregated}, self.compressor, "grad"
+        )
+        proto = tensordict_to_proto(compressed, compressor_proto_name(self.compressor))
+        decoded, _ = proto_to_tensordict_extended(proto, overlay_base=None)
+        self.assertEqual(decoded["w"].shape, aggregated.shape)
+        nnz = (decoded["w"] != 0).sum().item()
+        self.assertGreater(nnz, 0)
+        self.assertLess(nnz, aggregated.numel())
+
+    def test_dense_payload_when_compressor_none(self) -> None:
+        """BN / sample-count aggs pass compressor=None (num_samples=0 on wire)."""
+        bn = torch.tensor([0.1, 0.2, 0.3, 0.4])
+        payload = {"running_mean": bn}
+        dense = compress_message_tensors(payload, None, "grad")
+        self.assertIs(dense["running_mean"], bn)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_slurm_grpc_ready.py
+++ b/tests/test_slurm_grpc_ready.py
@@ -1,0 +1,70 @@
+"""Slurm multi-node gRPC startup: Lustre ready-marker helpers."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import threading
+import time
+import unittest
+from unittest.mock import MagicMock
+
+from src.omnifed.slurm_worker import (
+    _grpc_server_ready_marker,
+    _resolve_slurm_device,
+    _wait_for_grpc_server_ready_marker,
+    _write_grpc_server_ready_marker,
+)
+
+
+class TestSlurmGrpcReadyMarker(unittest.TestCase):
+    def test_marker_path_under_engine(self) -> None:
+        path = _grpc_server_ready_marker("/tmp/run")
+        self.assertTrue(path.endswith(os.path.join("engine", ".grpc_server_ready")))
+
+    def test_wait_returns_when_marker_appears(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            marker = _grpc_server_ready_marker(tmp)
+
+            def _writer() -> None:
+                time.sleep(0.3)
+                _write_grpc_server_ready_marker(
+                    tmp, master_addr="host1", master_port="50051"
+                )
+
+            t = threading.Thread(target=_writer, daemon=True)
+            t.start()
+            _wait_for_grpc_server_ready_marker(
+                tmp, rank=3, timeout_s=5.0, poll_s=0.05
+            )
+            self.assertTrue(os.path.isfile(marker))
+            t.join(timeout=2.0)
+
+
+class TestResolveSlurmDevice(unittest.TestCase):
+    def _grpc_server_comm(self) -> MagicMock:
+        comm = MagicMock()
+        comm.is_server = True
+        comm.backend = "nccl"
+        comm.master_port = 50051
+        return comm
+
+    def test_grpc_server_rank0_explicit_cpu_hint(self) -> None:
+        node = MagicMock()
+        node.device_hint = "cpu"
+        dev = _resolve_slurm_device(
+            node, rank=0, local_rank=0, local_comm=self._grpc_server_comm()
+        )
+        self.assertEqual(dev.type, "cpu")
+
+    def test_explicit_device_hint_cuda(self) -> None:
+        node = MagicMock()
+        node.device_hint = "cuda:1"
+        dev = _resolve_slurm_device(
+            node, rank=1, local_rank=0, local_comm=self._grpc_server_comm()
+        )
+        self.assertEqual(str(dev), "cuda:1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_torchdist_compression_classic.py
+++ b/tests/test_torchdist_compression_classic.py
@@ -1,0 +1,168 @@
+"""TorchDist Top-K / QSGD aggregation (classic sync grad)."""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+import torch.nn as nn
+
+from src.omnifed.communicator.base import AggregationOp
+from src.omnifed.communicator.compression.quantization import QSGDQuantCompression
+from src.omnifed.communicator.compression.sparsification import TopKCompression
+from src.omnifed.communicator.torchdist import TorchDistCommunicator
+from src.omnifed.communicator.compression.torchdist_collectives import (
+    aggregate_qsgd_tensor,
+    aggregate_topk_tensor,
+    all_gather_sparse_sum,
+)
+
+
+class TestAllGatherSparseSum(unittest.TestCase):
+    def test_sums_two_rank_payloads(self) -> None:
+        calls: list[int] = []
+
+        def fake_all_gather(out_list, inp):
+            step = len(calls)
+            calls.append(step)
+            if inp.numel() == 1:
+                out_list[0].copy_(torch.tensor([2], dtype=torch.long))
+                out_list[1].copy_(torch.tensor([2], dtype=torch.long))
+                return
+            if inp.dtype == torch.long:
+                out_list[0].copy_(torch.tensor([0, 2], dtype=torch.long))
+                out_list[1].copy_(torch.tensor([1, 0], dtype=torch.long))
+            else:
+                out_list[0].copy_(torch.tensor([1.0, 3.0]))
+                out_list[1].copy_(torch.tensor([2.0, 4.0]))
+
+        with mock.patch(
+            "src.omnifed.communicator.compression.torchdist_collectives.dist.all_gather",
+            side_effect=fake_all_gather,
+        ):
+            out = all_gather_sparse_sum(
+                torch.tensor([1.0, 3.0]),
+                torch.tensor([0, 2], dtype=torch.long),
+                numel=4,
+                world_size=2,
+                device=torch.device("cpu"),
+                dtype=torch.float32,
+            )
+
+        expected = torch.tensor([5.0, 2.0, 3.0, 0.0])
+        torch.testing.assert_close(out, expected)
+
+
+class TestTorchDistCompressionAggregate(unittest.TestCase):
+    def test_topk_skips_when_num_samples_zero(self) -> None:
+        comm = TorchDistCommunicator(
+            rank=0,
+            world_size=2,
+            master_port=29610,
+            communicate_params=False,
+            compressor=TopKCompression(device="cpu", compress_ratio=0.5),
+        )
+        comm.set_aggregation_num_samples(0)
+        t = torch.tensor([1.0, 2.0])
+        with mock.patch(
+            "src.omnifed.communicator.torchdist.dist.all_reduce",
+            side_effect=lambda tensor, **kw: tensor.mul_(2.0),
+        ) as mock_reduce:
+            comm.aggregate(t, AggregationOp.SUM)
+            self.assertEqual(mock_reduce.call_count, 1)
+            torch.testing.assert_close(t, torch.tensor([2.0, 4.0]))
+
+    def test_topk_compresses_when_num_samples_positive(self) -> None:
+        comm = TorchDistCommunicator(
+            rank=0,
+            world_size=2,
+            master_port=29611,
+            communicate_params=False,
+            compressor=TopKCompression(device="cpu", compress_ratio=0.5),
+        )
+        comm.set_aggregation_num_samples(8)
+        model = nn.Linear(4, 1, bias=False)
+        model.weight.grad = torch.tensor([[4.0, 0.0, -1.0, 2.0]])
+
+        with mock.patch(
+            "src.omnifed.communicator.torchdist.aggregate_topk_tensor",
+            return_value=torch.ones(1, 4),
+        ) as mock_topk:
+            comm.aggregate(model, AggregationOp.SUM)
+            mock_topk.assert_called_once()
+            torch.testing.assert_close(model.weight.grad, torch.ones(1, 4))
+
+    def test_topk_compresses_params_when_communicate_params_true(self) -> None:
+        comm = TorchDistCommunicator(
+            rank=0,
+            world_size=2,
+            master_port=29612,
+            communicate_params=True,
+            compressor=TopKCompression(device="cpu", compress_ratio=0.5),
+        )
+        comm.set_aggregation_num_samples(8)
+        model = nn.Linear(4, 1, bias=False)
+        model.weight.data.copy_(torch.tensor([[1.0, 2.0, 3.0, 4.0]]))
+
+        with mock.patch(
+            "src.omnifed.communicator.torchdist.aggregate_topk_tensor",
+            return_value=torch.full((1, 4), 0.5),
+        ) as mock_topk:
+            comm.aggregate(model, AggregationOp.SUM)
+            mock_topk.assert_called_once()
+            torch.testing.assert_close(model.weight.data, torch.full((1, 4), 0.5))
+
+    def test_qsgd_decompress_then_all_reduce(self) -> None:
+        torch.manual_seed(0)
+        compressor = QSGDQuantCompression(device="cpu", bit_width=4)
+        grad = torch.tensor([1.0, -2.0, 0.5, 3.0])
+        signed, norm, width, levels = compressor.compress(grad.clone(), "w")
+        local = QSGDQuantCompression.decompress_quantized(
+            signed, norm, levels, grad.shape
+        )
+
+        def fake_all_reduce(tensor, op=None, group=None, async_op=False):
+            del op, group, async_op
+            tensor.copy_(local * 2.0)
+
+        with mock.patch(
+            "src.omnifed.communicator.compression.torchdist_collectives.dist.all_reduce",
+            side_effect=fake_all_reduce,
+        ):
+            out = aggregate_qsgd_tensor(
+                compressor,
+                grad.clone(),
+                name="w",
+                op=mock.Mock(),
+                logger=None,
+            )
+        torch.testing.assert_close(out, local * 2.0)
+
+    def test_compress_decompress_timings_recorded(self) -> None:
+        compressor = TopKCompression(device="cpu", compress_ratio=0.5)
+        logger = SimpleNamespace(_summary_iter_comm={})
+        grad = torch.tensor([1.0, -2.0, 0.0, 4.0])
+
+        with mock.patch(
+            "src.omnifed.communicator.compression.torchdist_collectives.dist.all_gather",
+            side_effect=lambda out_list, inp: [
+                o.copy_(inp if i == 0 else inp) for i, o in enumerate(out_list)
+            ],
+        ):
+            aggregate_topk_tensor(
+                compressor,
+                grad,
+                name="w",
+                world_size=1,
+                logger=logger,
+            )
+
+        self.assertIn("grpc_compress_s", logger._summary_iter_comm)
+        self.assertIn("grpc_decompress_s", logger._summary_iter_comm)
+        self.assertGreater(logger._summary_iter_comm["grpc_compress_s"], 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_torchdist_grad_sync.py
+++ b/tests/test_torchdist_grad_sync.py
@@ -1,0 +1,80 @@
+"""TorchDistCommunicator grad-mode aggregation for classic sync grad."""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+import torch
+import torch.nn as nn
+
+from src.omnifed.communicator.base import AggregationOp
+from src.omnifed.communicator.torchdist import TorchDistCommunicator
+
+
+class _TinyLinear(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.lin = nn.Linear(4, 2)
+
+
+class TestTorchDistGradSync(unittest.TestCase):
+    def test_grad_mode_all_reduces_grads_not_params(self) -> None:
+        comm = TorchDistCommunicator(
+            rank=0,
+            world_size=2,
+            master_port=29500,
+            communicate_params=False,
+        )
+        model = _TinyLinear()
+        model.lin.weight.grad = torch.ones_like(model.lin.weight)
+        model.lin.bias.grad = torch.full_like(model.lin.bias, 2.0)
+        weight_before = model.lin.weight.detach().clone()
+        bias_before = model.lin.bias.detach().clone()
+
+        reduced: list[torch.Tensor] = []
+
+        def fake_all_reduce(tensor, op=None, group=None, async_op=False):
+            del op, group, async_op
+            reduced.append(tensor.detach().clone())
+            tensor.mul_(2.0)
+
+        with mock.patch("src.omnifed.communicator.torchdist.dist.all_reduce", fake_all_reduce):
+            comm.aggregate(model, AggregationOp.SUM)
+
+        self.assertEqual(len(reduced), 2)
+        torch.testing.assert_close(model.lin.weight, weight_before)
+        torch.testing.assert_close(model.lin.bias, bias_before)
+        torch.testing.assert_close(model.lin.weight.grad, torch.full_like(model.lin.weight, 2.0))
+        torch.testing.assert_close(model.lin.bias.grad, torch.full_like(model.lin.bias, 4.0))
+
+    def test_param_mode_all_reduces_weights_not_grads(self) -> None:
+        comm = TorchDistCommunicator(
+            rank=0,
+            world_size=2,
+            master_port=29501,
+            communicate_params=True,
+        )
+        model = _TinyLinear()
+        model.lin.weight.data.fill_(1.0)
+        model.lin.bias.data.fill_(2.0)
+
+        with mock.patch("src.omnifed.communicator.torchdist.dist.all_reduce") as mock_reduce:
+            comm.aggregate(model, AggregationOp.SUM)
+
+        reduced_tensors = [call.args[0] for call in mock_reduce.call_args_list]
+        self.assertEqual(len(reduced_tensors), 2)
+        reduced_shapes = {tuple(t.shape) for t in reduced_tensors}
+        self.assertEqual(
+            reduced_shapes,
+            {tuple(model.lin.weight.shape), tuple(model.lin.bias.shape)},
+        )
+
+    def test_set_aggregation_num_samples_api(self) -> None:
+        comm = TorchDistCommunicator(rank=0, world_size=1, master_port=29502)
+        comm.set_aggregation_num_samples(128)
+        self.assertEqual(comm._aggregation_num_samples, 128)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements [#90](https://github.com/at-aaims/OmniFed/issues/90): pluggable compression on the **centralized classic Slurm** pipeline.
- **Sync modes:** grad and param aggregation (`engine.classic.aggregate_payload`)
- **Compression:** dense(no compression), Top-K, QSGD
- **Communicator:** gRPC and TorchDist
- **Summary:** shared `src/omnifed/summary/` package (per-round + per-iteration CSV)
- **Configs:** 12 Hydra presets under `conf/test_pi_centralized_sync_*` (CIFAR-10 / ResNet-18)
- **Scripts:** post-run summary helpers only (`write_classic_per_round_summary.py`, etc.)
Closes #90

## Test plan
- [x] Local minimal pytest (36 passed):
  - classic grad/param slurm, summary, engine frozen cfg, slurm gRPC ready
  - gRPC grad buffers / Top-K / QSGD / sample-weighted
  - TorchDist grad sync + compression
- [ ] Frontier Slurm smoke: `conf/test_pi_centralized_sync_grad_cifar10_resnet18_grpc.yaml`
- [ ] Optional matrix: remaining 11 presets (grad/param × dense/topk/qsgd × grpc/torchdist)
## Notes
- TorchDist collectives live in `communicator/compression/torchdist_collectives.py`.