### PR TITLE
Fix/frontier 8 gpu

### DIFF
--- a/conf/base.yaml
+++ b/conf/base.yaml
@@ -144,7 +144,7 @@ slurm:
   time: "02:00:00"
   nodes: 2
   ntasks_per_node: 1
-  cpus_per_task: 8
+  cpus_per_task: 6
   gpus_per_node: 1
   gpus_per_task: 1
   gres: gpu:1
@@ -156,7 +156,7 @@ slurm:
   setup_lines:
     # site modules/env (edit for Frontier/site)
     - 'module load cray-python || true'
-    - 'export OMP_NUM_THREADS=8'
+    - 'export OMP_NUM_THREADS="${SLURM_CPUS_PER_TASK:-1}"'
   # Parent Lustre dir for hybrid round checkpoints; use with ``experiment_id``.
   checkpoint_dir: null
   # Subdirectory under ``checkpoint_dir`` (stable across resubmits). See ``docs/CHECKPOINTING_HYBRID_SLURM_PLAN.md``.

--- a/conf/base.yaml
+++ b/conf/base.yaml
@@ -156,7 +156,7 @@ slurm:
   setup_lines:
     # site modules/env (edit for Frontier/site)
     - 'module load cray-python || true'
-    - 'export OMP_NUM_THREADS="${SLURM_CPUS_PER_TASK:-1}"'
+    - 'export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK'
   # Parent Lustre dir for hybrid round checkpoints; use with ``experiment_id``.
   checkpoint_dir: null
   # Subdirectory under ``checkpoint_dir`` (stable across resubmits). See ``docs/CHECKPOINTING_HYBRID_SLURM_PLAN.md``.

--- a/src/omnifed/engine.py
+++ b/src/omnifed/engine.py
@@ -346,6 +346,10 @@ class Engine(RequiredSetup):
                     "module load rocm/6.4.1",
                     "module load craype-accel-amd-gfx90a",
                     "module load miniforge3/23.11.0-0",
+
+                    # Match CPU threading to #SBATCH --cpus-per-task
+                    'export OMP_NUM_THREADS="$SLURM_CPUS_PER_TASK"',
+                    'echo "[setup] OMP_NUM_THREADS=$OMP_NUM_THREADS"',
                     # MNIST + caches (torchvision reads OMNIFED_DATA_DIR)
                     # 'export OMNIFED_DATA_DIR="/lustre/orion/gen150/scratch/shruti2395/omnifed_data"',
                     # 'mkdir -p "$OMNIFED_DATA_DIR"',

--- a/src/omnifed/engine.py
+++ b/src/omnifed/engine.py
@@ -49,6 +49,7 @@ from omegaconf import OmegaConf
 from .slurm_launcher import SlurmConfig, SlurmOnlyLauncher
 from .engine_communication import communication_mode, resolve_slurm_ntasks
 import sys
+import shlex
 
 LOG_FLUSH_DELAY = 2.0
 
@@ -336,7 +337,8 @@ class Engine(RequiredSetup):
                 sconf.stderr = os.path.join(self.hydra_cfg.runtime.output_dir, "slurm-%j.err")
 
                 # IMPORTANT: this python is only used before setup_lines runs
-                sconf.pyexe = "python"
+                # sconf.pyexe = "python"
+                sconf.pyexe = sys.executable
 
                 # 4) Frontier / site environment (edit paths for your user + conda env)
                 sconf.setup_lines = [
@@ -345,13 +347,16 @@ class Engine(RequiredSetup):
                     "module load craype-accel-amd-gfx90a",
                     "module load miniforge3/23.11.0-0",
                     # MNIST + caches (torchvision reads OMNIFED_DATA_DIR)
-                    'export OMNIFED_DATA_DIR="/lustre/orion/gen150/scratch/shruti2395/omnifed_data"',
-                    'mkdir -p "$OMNIFED_DATA_DIR"',
-                    'echo "[setup] OMNIFED_DATA_DIR=$OMNIFED_DATA_DIR"',
+                    # 'export OMNIFED_DATA_DIR="/lustre/orion/gen150/scratch/shruti2395/omnifed_data"',
+                    # 'mkdir -p "$OMNIFED_DATA_DIR"',
+                    # 'echo "[setup] OMNIFED_DATA_DIR=$OMNIFED_DATA_DIR"',
                     # Use your conda env Python on compute nodes (no conda-pack / sbcast)
-                    'export PYEXE="/ccs/home/shruti2395/.conda/envs/pytorch_rocm/bin/python"',
+                    # 'export PYEXE="/ccs/home/shruti2395/.conda/envs/pytorch_rocm/bin/python"',
+                    # 'echo "[setup] PYEXE=$PYEXE"',
+                    # '"$PYEXE" -c "import torch; print(torch.__version__)"',
+                    f"export PYEXE={shlex.quote(sconf.pyexe)}",
                     'echo "[setup] PYEXE=$PYEXE"',
-                    '"$PYEXE" -c "import torch; print(torch.__version__)"',
+                    '"$PYEXE" -c "import sys, torch; print(sys.executable); print(torch.__version__)"',
                     "",
                     "export MIOPEN_USER_DB_PATH=/tmp/${USER}/miopen-cache",
                     "export MIOPEN_CUSTOM_CACHE_DIR=${MIOPEN_USER_DB_PATH}",

--- a/src/omnifed/slurm_launcher.py
+++ b/src/omnifed/slurm_launcher.py
@@ -21,7 +21,7 @@ class SlurmConfig:
     time: str = "02:00:00"
     nodes: int = 2
     ntasks_per_node: int = 1
-    cpus_per_task: int = 8
+    cpus_per_task: int = 6
 
     # GPU options
     gres: Optional[str] = None

--- a/src/omnifed/slurm_launcher.py
+++ b/src/omnifed/slurm_launcher.py
@@ -123,7 +123,8 @@ class SlurmOnlyLauncher:
         lines += sconf.sbatch_lines()
         lines += [
             "set -euo pipefail",
-            f'export PYTHONPATH="${{PYTHONPATH:-}}:{repo_root}"',
+            # f'export PYTHONPATH="${{PYTHONPATH:-}}:{repo_root}"',
+            f'export PYTHONPATH="{repo_root}:${{PYTHONPATH:-}}"',
             'export PYTHONUNBUFFERED=1',
             'export HYDRA_FULL_ERROR=1',
             'export OMNIFED_DEBUG=${OMNIFED_DEBUG:-0}',


### PR DESCRIPTION
I edited the cpus_per_task=6 in base.yaml, slurm_launcher file , 'export OMP_NUM_THREADS=$SLURM_CPUS_PER_TASK'
In engine class there were hardcoded dataset path and environment path, I fixed those also.